### PR TITLE
Add shift-click, ctrl-click support for visualization plot selection.

### DIFF
--- a/src/containers/SortingView.js
+++ b/src/containers/SortingView.js
@@ -12,6 +12,7 @@ const pluginComponentsList = Object.values(pluginComponents).filter(PluginCompon
 const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo }) => {
   const [sortingInfoStatus, setSortingInfoStatus] = useState(null);
   const [selectedUnitIds, setSelectedUnitIds] = useState({});
+  const [focusedUnitId, setFocusedUnitId] = useState(null);
 
   const effect = async () => {
     if ((sorting) && (recording) && (!sorting.sortingInfo)) {
@@ -29,6 +30,10 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo }) => {
 
   const handleSelectedUnitIdsChanged = (selectedUnitIds) => {
     setSelectedUnitIds(selectedUnitIds);
+  }
+
+  const handleFocusedUnitIdChanged = (focusedUnitId) => {
+    setFocusedUnitId(focusedUnitId);
   }
 
   if (!sorting) {
@@ -59,7 +64,9 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo }) => {
                   sorting={sorting}
                   recording={recording}
                   selectedUnitIds={selectedUnitIds}
+                  focusedUnitId={focusedUnitId}
                   onSelectedUnitIdsChanged={(selectedUnitIds) => handleSelectedUnitIdsChanged(selectedUnitIds)}
+                  onFocusedUnitIdChanged={(focusedUnitId) => handleFocusedUnitIdChanged(focusedUnitId)}
                 />
               </Expandable>
             )


### PR DESCRIPTION
Updates unit selection functionality to match the following standard:

 - **Ctrl-click**: if an element is clicked with the control modifier key pressed, the presence of the shift modifier key is ignored. Instead, we simply toggle the selection status of the clicked element, without altering the selection status of any other selectable visual element, and reset the focus to the last-clicked element. (Note that focus is changed even if we de-selected the last clicked element.)
 - **Shift-click**: If a focus is not set, this is identical to an unmodified click. If the focus is set, then the currently selected elements will be set to those which fall in the range between the clicked-upon element and the focus element, inclusive.
 - **Unmodified click**: Set the selection list to only the element clicked upon. The focus element will be set to the element clicked upon, only.

Still outstanding:
--
 - These changes currently live within the `Autocorrelograms.js` plugin and so are limited to this one visualization. We will almost certainly want to move them somewhere more general so that they can be accessed in a consistent manner by visualizations yet-to-be-added.
 - We do not yet have integration with other references to units in the display, such as the text list of units above the expandable-sections.
 - Drag-selection has not yet been implemented.