### PR TITLE
Separate plot labels from plots. Improve selection highlights.

### DIFF
--- a/src/components/MatplotlibPlot.js
+++ b/src/components/MatplotlibPlot.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { createHitherJob } from '../hither'
 import { sleep } from '../actions';
 import { CircularProgress } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 const mpld3 = require('./mpld3.v0.3.js');
 
 const MatplotlibPlot = ({ functionName, functionArgs }) => {
@@ -48,7 +49,15 @@ const MatplotlibPlot = ({ functionName, functionArgs }) => {
     useEffect(() => { effect(); })
     return (
         status === 'calculating' ? (
-            <div><CircularProgress /></div>
+            // TODO: Centralize this styling
+            <Box
+                display="flex" 
+                width={200} height={200} 
+            >
+                <Box m="auto">
+                    <CircularProgress />
+                </Box>
+          </Box>
         ) : (
             <div key={divId} ref={plotRef} id={divId} /> 
         )

--- a/src/components/SortingInfoView.js
+++ b/src/components/SortingInfoView.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import { Table, TableHead, TableRow, TableBody, TableCell } from '@material-ui/core';
 
-const SortingInfoView = ({ sortingInfo, selectedUnitIds, focusedUnitId, onSelectedUnitIdsChanged,
-                            onFocusedUnitIdChanged  }) => {
+const SortingInfoView = ({ sortingInfo, isSelected, isFocused, handleUnitClicked }) => {
     const si = sortingInfo;
     if (!si) return <div>No sorting info found</div>;
 
@@ -37,59 +35,7 @@ const SortingInfoView = ({ sortingInfo, selectedUnitIds, focusedUnitId, onSelect
             </div>
         )
     }
-    
-    const isSelected = (unitId) => {
-        return selectedUnitIds[unitId] || false;
-    }
-    
-    const isFocused = (unitId) => {
-        return (focusedUnitId ?? -1) === unitId;
-    }
-
-    const intrange = (a, b) => {
-        const lower = a < b ? a : b;
-        const upper = a < b ? b : a;
-        let arr = [];
-        for (let n = lower; n <= upper; n++) {
-            arr.push(n);
-        }
-        return arr;
-    }
-    
-    // TODO: Code is all cut and pasted from AutoCorrelograms.js
-    // Move to somewhere where it can actually be shared & DON'T repeat it
-    const handleUnitClicked = (unitId, event) => {
-        let newSelectedUnitIds = [];
-        if (event.ctrlKey){
-            // if ctrl modifier is set, ignore shift status, then:
-            // 1. Toggle clicked element only (don't touch any existing elements) &
-            // 2. Set focused id to clicked id (regardless of toggle status)
-            newSelectedUnitIds = {
-                ...selectedUnitIds,
-                [unitId]: !(selectedUnitIds[unitId] || false)
-            }
-            onFocusedUnitIdChanged(unitId);
-        }
-        else if (event.shiftKey && focusedUnitId) {
-            // if shift modifier (without ctrl modifier) & a focus exists:
-            // Set selected elements to those between focus and click, inclusive.
-            const intUnitId = parseInt(unitId);
-            newSelectedUnitIds = Object.fromEntries(
-                intrange(intUnitId, focusedUnitId).map(key => [key, true])
-            );
-            // do not reset focus -- no call to onFocusedUnitIdChanged()
-        }
-        else {
-            // simple click, or shift-click without focus.
-            // Select only the clicked element, and set it to focus,
-            newSelectedUnitIds = {
-                [unitId]: !(selectedUnitIds[unitId] || false)
-            }
-            onFocusedUnitIdChanged(isFocused(unitId) ? null : unitId);
-        }
-        onSelectedUnitIdsChanged(newSelectedUnitIds);
-    }
-    
+        
     function clickabilize(unitId, idx, ary) {
         return (
             <span

--- a/src/components/SortingInfoView.js
+++ b/src/components/SortingInfoView.js
@@ -1,38 +1,113 @@
 import React from 'react'
 import { Table, TableHead, TableRow, TableBody, TableCell } from '@material-ui/core';
 
-const SortingInfoView = ({ sortingInfo  }) => {
+const SortingInfoView = ({ sortingInfo, selectedUnitIds, focusedUnitId, onSelectedUnitIdsChanged,
+                            onFocusedUnitIdChanged  }) => {
     const si = sortingInfo;
     if (!si) return <div>No sorting info found</div>;
+
+    const labelStyle = {
+        'minWidth': '200px',
+        'display': 'inline-block'
+    }
+    
+    const focusedStyle = {
+        'fontWeight': 'bold',
+        color: '#4287f5',
+        'backgroundColor': 'white'
+    }
+    
+    const selectedStyle = {
+        'fontWeight': 'bold',
+        color: 'blue',
+        'backgroundColor': 'white'
+    }
+    
+    const unselectedStyle = {
+        'fontWeight': 'normal',
+        color: 'black',
+        'backgroundColor': 'white'
+    }
+    
+    const SortingViewDiv = ({ unit_ids }) => {
+        return (
+            <div style={{ width: 600 }}>
+                <span style={labelStyle}>Unit IDs</span>
+                <span>{unit_ids.map((unitId, idx, ary) => clickabilize(unitId, idx, ary))} </span>
+            </div>
+        )
+    }
+    
+    const isSelected = (unitId) => {
+        return selectedUnitIds[unitId] || false;
+    }
+    
+    const isFocused = (unitId) => {
+        return (focusedUnitId ?? -1) === unitId;
+    }
+
+    const intrange = (a, b) => {
+        const lower = a < b ? a : b;
+        const upper = a < b ? b : a;
+        let arr = [];
+        for (let n = lower; n <= upper; n++) {
+            arr.push(n);
+        }
+        return arr;
+    }
+    
+    // TODO: Code is all cut and pasted from AutoCorrelograms.js
+    // Move to somewhere where it can actually be shared & DON'T repeat it
+    const handleUnitClicked = (unitId, event) => {
+        let newSelectedUnitIds = [];
+        if (event.ctrlKey){
+            // if ctrl modifier is set, ignore shift status, then:
+            // 1. Toggle clicked element only (don't touch any existing elements) &
+            // 2. Set focused id to clicked id (regardless of toggle status)
+            newSelectedUnitIds = {
+                ...selectedUnitIds,
+                [unitId]: !(selectedUnitIds[unitId] || false)
+            }
+            onFocusedUnitIdChanged(unitId);
+        }
+        else if (event.shiftKey && focusedUnitId) {
+            // if shift modifier (without ctrl modifier) & a focus exists:
+            // Set selected elements to those between focus and click, inclusive.
+            const intUnitId = parseInt(unitId);
+            newSelectedUnitIds = Object.fromEntries(
+                intrange(intUnitId, focusedUnitId).map(key => [key, true])
+            );
+            // do not reset focus -- no call to onFocusedUnitIdChanged()
+        }
+        else {
+            // simple click, or shift-click without focus.
+            // Select only the clicked element, and set it to focus,
+            newSelectedUnitIds = {
+                [unitId]: !(selectedUnitIds[unitId] || false)
+            }
+            onFocusedUnitIdChanged(isFocused(unitId) ? null : unitId);
+        }
+        onSelectedUnitIdsChanged(newSelectedUnitIds);
+    }
+    
+    function clickabilize(unitId, idx, ary) {
+        return (
+            <span
+                key={unitId}
+                style={isSelected(unitId) ? (isFocused(unitId)? focusedStyle: selectedStyle) : unselectedStyle}
+                onClick={(event) => handleUnitClicked(unitId, event)}
+            >
+                {unitId}{idx === ary.length - 1 ? '' : ', '}
+            </span>
+        );
+    }
+
     return (
         <div>
-            <div style={{ width: 600 }}>
-                <SortingViewTable
-                    unit_ids={si.unit_ids}
-                />
-            </div>
+            <SortingViewDiv unit_ids={si.unit_ids}
+            />
         </div>
     );
-}
-
-const SortingViewTable = ({ unit_ids }) => {
-    return (
-        <Table>
-            <TableHead>
-            </TableHead>
-            <TableBody>
-                <TableRow>
-                    <TableCell>Unit IDs</TableCell>
-                    <TableCell>{commasep(unit_ids)}</TableCell>
-                </TableRow>
-            </TableBody>
-        </Table>
-    )
-}
-
-function commasep(x) {
-    if (!x) return JSON.stringify(x);
-    return x.join(', ');
 }
 
 export default SortingInfoView;

--- a/src/containers/SortingView.js
+++ b/src/containers/SortingView.js
@@ -47,7 +47,12 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo }) => {
         (sortingInfoStatus === 'computing') ? (
           <div><CircularProgress /></div>
         ) : (
-          <SortingInfoView sortingInfo={sorting.sortingInfo} />
+          <SortingInfoView sortingInfo={sorting.sortingInfo}
+            selectedUnitIds={selectedUnitIds}
+            focusedUnitId={focusedUnitId}
+            onSelectedUnitIdsChanged={(selectedUnitIds) => handleSelectedUnitIdsChanged(selectedUnitIds)}
+            onFocusedUnitIdChanged={(focusedUnitId) => handleFocusedUnitIdChanged(focusedUnitId)}
+          />
         )
       }
       <div>

--- a/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
+++ b/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
@@ -14,19 +14,21 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
     }
 
     // TODO: Should this go in a stylesheet?
+    // TODO: In any event it should definitely be shared with other components
+    // Maybe pass in a "styles" object?
     const wrapperStyle = {
-        'min-height': '228px',
-        'min-width': '206px',
+        'minHeight': '228px',
+        'minWidth': '206px',
     }
 
     const focusedStyle = {
         border: 'solid 3px #4287f5',
-        'background-color': '#b5d1ff'
+        'backgroundColor': '#b5d1ff'
     }
 
     const selectedStyle = {
         border: 'solid 3px blue',
-        'background-color': '#b5d1ff'
+        'backgroundColor': '#b5d1ff'
     }
 
     const unselectedStyle = {
@@ -88,7 +90,7 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
                                 style={isSelected(unitId) ? (isFocused(unitId) ? focusedStyle : selectedStyle) : unselectedStyle}
                                 onClick={(event) => handleUnitClicked(unitId, event)}
                             >
-                                <div style={{'text-align': 'center'}}>
+                                <div style={{'textAlign': 'center'}}>
                                     <div>Unit {unitId}</div>
                                 </div>
                                 <MatplotlibPlot

--- a/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
+++ b/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
@@ -9,8 +9,28 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
         return selectedUnitIds[unitId] || false;
     }
 
+    const isFocused = (unitId) => {
+        return (focusedUnitId ?? -1) === unitId;
+    }
+
+    // TODO: Should this go in a stylesheet?
+    const wrapperStyle = {
+        'min-height': '228px',
+        'min-width': '206px',
+    }
+
+    const focusedStyle = {
+        border: 'solid 3px #4287f5',
+        'background-color': '#b5d1ff'
+    }
+
     const selectedStyle = {
-        border: 'solid 3px blue'
+        border: 'solid 3px blue',
+        'background-color': '#b5d1ff'
+    }
+
+    const unselectedStyle = {
+        border: 'solid 3px transparent'
     }
 
     // TODO: move somewhere better
@@ -48,11 +68,11 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
         }
         else {
             // simple click, or shift-click without focus.
-            // Select only the clicked element, and set it to focus.
+            // Select only the clicked element, and set it to focus,
             newSelectedUnitIds = {
                 [unitId]: !(selectedUnitIds[unitId] || false)
             }
-            onFocusedUnitIdChanged(unitId);
+            onFocusedUnitIdChanged(isFocused(unitId) ? null : unitId);
         }
         onSelectedUnitIdsChanged(newSelectedUnitIds);
     }
@@ -62,17 +82,23 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
             {
                 sorting.sortingInfo.unit_ids.map(unitId => (
                     <Grid key={unitId} item>
-                        <div
-                            style={isSelected(unitId) ? selectedStyle : {}}
-                            onClick={(event) => handleUnitClicked(unitId, event)}
+                        <div style={wrapperStyle}
                         >
-                            <MatplotlibPlot
-                                functionName='genplot_autocorrelogram'
-                                functionArgs={{
-                                    sorting_object: sorting.sortingObject,
-                                    unit_id: unitId
-                                }}
-                            />
+                            <div
+                                style={isFocused(unitId) ? focusedStyle : isSelected(unitId) ? selectedStyle : unselectedStyle}
+                                onClick={(event) => handleUnitClicked(unitId, event)}
+                            >
+                                <div style={{'text-align': 'center'}}>
+                                    <div>Unit {unitId}</div>
+                                </div>
+                                <MatplotlibPlot
+                                    functionName='genplot_autocorrelogram'
+                                    functionArgs={{
+                                        sorting_object: sorting.sortingObject,
+                                        unit_id: unitId
+                                    }}
+                                />
+                            </div>
                         </div>
                     </Grid>
                 ))

--- a/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
+++ b/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
@@ -85,7 +85,7 @@ const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedU
                         <div style={wrapperStyle}
                         >
                             <div
-                                style={isFocused(unitId) ? focusedStyle : isSelected(unitId) ? selectedStyle : unselectedStyle}
+                                style={isSelected(unitId) ? (isFocused(unitId) ? focusedStyle : selectedStyle) : unselectedStyle}
                                 onClick={(event) => handleUnitClicked(unitId, event)}
                             >
                                 <div style={{'text-align': 'center'}}>

--- a/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
+++ b/src/pluginComponents/AutoCorrelograms/AutoCorrelograms.js
@@ -2,92 +2,21 @@ import React from 'react'
 import MatplotlibPlot from '../../components/MatplotlibPlot';
 import { Grid } from '@material-ui/core';
 
-const AutoCorrelograms = ({ sorting, selectedUnitIds, focusedUnitId, onSelectedUnitIdsChanged,
-                                onFocusedUnitIdChanged }) => {
-
-    const isSelected = (unitId) => {
-        return selectedUnitIds[unitId] || false;
-    }
-
-    const isFocused = (unitId) => {
-        return (focusedUnitId ?? -1) === unitId;
-    }
-
-    // TODO: Should this go in a stylesheet?
-    // TODO: In any event it should definitely be shared with other components
-    // Maybe pass in a "styles" object?
-    const wrapperStyle = {
-        'minHeight': '228px',
-        'minWidth': '206px',
-    }
-
-    const focusedStyle = {
-        border: 'solid 3px #4287f5',
-        'backgroundColor': '#b5d1ff'
-    }
-
-    const selectedStyle = {
-        border: 'solid 3px blue',
-        'backgroundColor': '#b5d1ff'
-    }
-
-    const unselectedStyle = {
-        border: 'solid 3px transparent'
-    }
-
-    // TODO: move somewhere better
-    const intrange = (a, b) => {
-        const lower = a < b ? a : b;
-        const upper = a < b ? b : a;
-        let arr = [];
-        for (let n = lower; n <= upper; n++) {
-            arr.push(n);
-        }
-        return arr;
-    }
-
-    // TODO: Move somewhere it can be reused
-    const handleUnitClicked = (unitId, event) => {
-        let newSelectedUnitIds = [];
-        if (event.ctrlKey){
-            // if ctrl modifier is set, ignore shift status, then:
-            // 1. Toggle clicked element only (don't touch any existing elements) &
-            // 2. Set focused id to clicked id (regardless of toggle status)
-            newSelectedUnitIds = {
-                ...selectedUnitIds,
-                [unitId]: !(selectedUnitIds[unitId] || false)
-            }
-            onFocusedUnitIdChanged(unitId);
-        }
-        else if (event.shiftKey && focusedUnitId) {
-            // if shift modifier (without ctrl modifier) & a focus exists:
-            // Set selected elements to those between focus and click, inclusive.
-            const intUnitId = parseInt(unitId);
-            newSelectedUnitIds = Object.fromEntries(
-                intrange(intUnitId, focusedUnitId).map(key => [key, true])
-            );
-            // do not reset focus -- no call to onFocusedUnitIdChanged()
-        }
-        else {
-            // simple click, or shift-click without focus.
-            // Select only the clicked element, and set it to focus,
-            newSelectedUnitIds = {
-                [unitId]: !(selectedUnitIds[unitId] || false)
-            }
-            onFocusedUnitIdChanged(isFocused(unitId) ? null : unitId);
-        }
-        onSelectedUnitIdsChanged(newSelectedUnitIds);
-    }
+const AutoCorrelograms = ({ sorting, isSelected, isFocused, handleUnitClicked, plotStyles }) => {
 
     return (
         <Grid container>
             {
                 sorting.sortingInfo.unit_ids.map(unitId => (
                     <Grid key={unitId} item>
-                        <div style={wrapperStyle}
+                        <div style={plotStyles['plotWrapperStyle']}
                         >
                             <div
-                                style={isSelected(unitId) ? (isFocused(unitId) ? focusedStyle : selectedStyle) : unselectedStyle}
+                                style={isSelected(unitId)
+                                    ? (isFocused(unitId)
+                                        ? plotStyles['plotFocusedStyle']
+                                        : plotStyles['plotSelectedStyle']
+                                    ) : plotStyles['unselectedStyle'] }
                                 onClick={(event) => handleUnitClicked(unitId, event)}
                             >
                                 <div style={{'textAlign': 'center'}}>

--- a/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
+++ b/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
@@ -20,7 +20,6 @@ def _plot_correlogram(*, ax, bin_counts, bins, wid, title='', color=None):
            width=wid*kk, color=color, align='edge')
     ax.set_xlabel('dt (msec)')
     ax.set_xticks([bins[0]*kk, bins[len(bins)//2]*kk, bins[-1]*kk])
-    ax.set_title(title)
     # ax.set_yticks([])
 
 
@@ -39,7 +38,7 @@ def _plot_autocorrelogram(ax, sorting, unit_id, window_size_msec, bin_size_msec)
         symmetrize=True
     )
     bins = np.linspace(- window_size / 2, window_size / 2, C.shape[2])
-    _plot_correlogram(ax=ax, bin_counts=C[0, 0, :], bins=bins, wid=bin_size, color='gray', title=f'Unit {unit_id}')
+    _plot_correlogram(ax=ax, bin_counts=C[0, 0, :], bins=bins, wid=bin_size, color='gray')
 
 
 def _plot_crosscorrelogram(ax, sorting, unit_id1, unit_id2, window_size_msec, bin_size_msec):


### PR DESCRIPTION
This PR does a fair amount of polishing for plot display:

 - Plot title no longer in the plot, but instead rendered in an HTML div component by the plot generator
 - Added separate styling for the focused element, so it's clear what shift-select will do (this also better matches what mountainview does)
 - Added an 'unselected' styling with a transparent border so that the elements inside the boxes don't move around when you click them
 - Ensured that deselection trumps the focus styling
 - Centered the 'loading' spinner inside the plots

Functionality is also improved:
 - The list of unit IDs is now displayed in clickable spans, with shared state between the selected unit IDs (visible from styling) and the selected plots. Clicking either one (which follow the same logic) will modify the state of the other.
 - To facilitate this, I bumped the selection logic, and the logic for identifying whether an individual component is selected/focused, up to the `SortingView` object. It is now passed in and can be shared.
 - Note this means some of the selection and selection-hook data is no longer being passed to individual components. I figure it's easy enough to add it back in, if we should wind up later on implementing components that need to do so.
 - Plot highlight/focus styling rules are now part of an object that's passed in to individual plot components, so they can be defined centrally and shared consistently.

Ongoing Todos:
 - There's still no logic calculating plot size (it's still hard-coded in pyplot, so it's still hard-coded in all the sizing styling which I now have living in `SortingView.js`).
 - There might be a more optimal way to organize the code that's now found a home in `SortingView.js`.