### PR TITLE
Removed brittle index-based unit selection.

### DIFF
--- a/src/components/NiceTable.js
+++ b/src/components/NiceTable.js
@@ -16,7 +16,6 @@ const NiceTable = ({
 }) => {
 
     const selectedRowKeysObj = {};
-    console.log(`Selected row keys: ${JSON.stringify(selectedRowKeys)}`)
     Object.keys(selectedRowKeys).forEach((key) => {selectedRowKeysObj[key] = selectedRowKeys[key]});
     const handleClickRow = (key) => {
         if (!onSelectedRowKeysChanged || false) return;
@@ -29,10 +28,6 @@ const NiceTable = ({
         }
         else if (selectionMode === 'multiple') {
             // todo: write this logic. Note, we'll need to also pass in the event to get the ctrl/shift modifiers
-            // I actually think the UI expectation for a checkbox is such that we shouldn't worry about modifier
-            // keys--just treat any click like a ctrl-click. (I would also, if possible, use radio buttons
-            // in place of checkboxes for the row selection in single-select mode.)
-            console.log(`Contents of selected row keys obj: ${JSON.stringify(selectedRowKeysObj)}`);
             onSelectedRowKeysChanged(
                 Object.keys(selectedRowKeysObj)
                     // eslint-disable-next-line eqeqeq

--- a/src/components/NiceTable.js
+++ b/src/components/NiceTable.js
@@ -11,12 +11,13 @@ const NiceTable = ({
     onEditRow,
     editRowLabel,
     selectionMode='none', // none, single, multiple
-    selectedRowKeys,
+    selectedRowKeys={},
     onSelectedRowKeysChanged
 }) => {
 
     const selectedRowKeysObj = {};
-    selectedRowKeys && selectedRowKeys.forEach((val, idx) => {selectedRowKeysObj[idx+1] = val});
+    console.log(`Selected row keys: ${JSON.stringify(selectedRowKeys)}`)
+    Object.keys(selectedRowKeys).forEach((key) => {selectedRowKeysObj[key] = selectedRowKeys[key]});
     const handleClickRow = (key) => {
         if (!onSelectedRowKeysChanged || false) return;
         if (selectionMode === 'single') {
@@ -31,6 +32,7 @@ const NiceTable = ({
             // I actually think the UI expectation for a checkbox is such that we shouldn't worry about modifier
             // keys--just treat any click like a ctrl-click. (I would also, if possible, use radio buttons
             // in place of checkboxes for the row selection in single-select mode.)
+            console.log(`Contents of selected row keys obj: ${JSON.stringify(selectedRowKeysObj)}`);
             onSelectedRowKeysChanged(
                 Object.keys(selectedRowKeysObj)
                     // eslint-disable-next-line eqeqeq
@@ -93,6 +95,8 @@ const NiceTable = ({
 };
 
 const makeCell = (x) => {
+    // eslint-disable-next-line eqeqeq
+    if (x == 0) return x;  // !'0' is true, but we shouldn't null out actual 0s
     if (!x) return '';
     if (typeof(x) == "object") {
         if (x.element) return x.element;

--- a/src/components/SortingInfoView.js
+++ b/src/components/SortingInfoView.js
@@ -1,50 +1,72 @@
 import React from 'react'
 
-const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked }) => {
+const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, curation, styling }) => {
     const si = sortingInfo;
     if (!si) return <div>No sorting info found</div>;
 
     const labelStyle = {
         'minWidth': '200px',
-        'display': 'inline-block'
+        'fontWeight': 'bold',
+        'padding': '7px 5px 7px 5px'
     }
     
     const focusedStyle = {
         'fontWeight': 'bold',
         color: '#4287f5',
-        'backgroundColor': 'white'
+        'backgroundColor': 'white',
     }
     
     const selectedStyle = {
         'fontWeight': 'bold',
         color: 'blue',
-        'backgroundColor': 'white'
+        'backgroundColor': 'white',
     }
     
     const unselectedStyle = {
         'fontWeight': 'normal',
         color: 'black',
+        'backgroundColor': 'white',
+    }
+
+    const unitIdStyle = {
+        'paddingRight': '13px',
+        'paddingTop': '10px'
+    }
+
+    const labelListStyle = {
+        'paddingRight': '3px',
+        'color': '#333333',
         'backgroundColor': 'white'
     }
     
     const SortingViewDiv = ({ unit_ids }) => {
         return (
-            <div style={{ width: 600 }}>
-                <span style={labelStyle}>Unit IDs</span>
-                <span>{unit_ids.map((unitId, idx, ary) => clickabilize(unitId, idx, ary))} </span>
+            <div style={styling}>
+                <div style={labelStyle}>Unit IDs</div>
+                {unit_ids.map((unitId, idx, ary) => clickabilize(unitId, idx, ary))}
             </div>
         )
     }
         
     function clickabilize(unitId, idx, ary) {
         return (
-            <span
+            <div
                 key={unitId}
                 style={(isSelected && isSelected(unitId)) ? (isFocused(unitId)? focusedStyle: selectedStyle) : unselectedStyle}
                 onClick={(event) => onUnitClicked(unitId, event)}
             >
-                {unitId}{idx === ary.length - 1 ? '' : ', '}
-            </span>
+                <span style={unitIdStyle}>{unitId}</span>
+                <span>
+                    {((curation[unitId] || {}).labels || [])
+                        .map((label) => {
+                            return (
+                                <span style={labelListStyle}>
+                                    {label}&nbsp;
+                                </span>
+                            )
+                        })}
+                </span>
+            </div>
         );
     }
 

--- a/src/containers/SortingView.js
+++ b/src/containers/SortingView.js
@@ -86,6 +86,24 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo, onAddUni
     setFocusedUnitId(focusedUnitId);
   }
 
+  const sidebarWidth = '200px'
+
+  const sidebarStyle = {
+    'width': sidebarWidth,
+    'height': '100%',
+    'position': 'absolute',
+    'zIndex': 1,
+    'top': 150,
+    'left': 0,
+    'overflowX': 'hidden',
+    'paddingTop': '20px',
+    'paddingLeft': '20px'
+  }
+
+  const contentWrapperStyle = {
+    'marginLeft': sidebarWidth
+  }
+
   if (!sorting) {
     return <h3>{`Sorting not found: ${sortingId}`}</h3>
   }
@@ -101,10 +119,12 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo, onAddUni
             isSelected={isSelected}
             isFocused={isFocused}
             onUnitClicked={handleUnitClicked}
+            curation={sorting.unitCuration || {}}
+            styling={sidebarStyle}
           />
         )
       }
-      <div>
+      <div style={contentWrapperStyle}>
         {
           pluginComponentsList.map(PluginComponent => {
             const config = PluginComponent.sortingViewPlugin;

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -29,10 +29,11 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         return 0;
     });
 
-    const selectedRowKeys = sorting.sortingInfo.unit_ids.map((id) => isSelected(id));
+    const selectedRowKeys = sorting.sortingInfo.unit_ids
+        .reduce((obj, id) => ({...obj, [id]: isSelected(id)}), {});
     const handleSelectedRowKeysChanged = (keys) => {
         onSelectedUnitIdsChanged(
-            keys.reduce((o, key) => Object.assign(o, {[key]: true}), {})
+            keys.reduce((o, key) => ({...o, [key]: true}), {})
         );
     }
     const getLabelsForUnitId = unitId => {
@@ -46,13 +47,13 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         onRemoveUnitLabel({sortingId: sorting.sortingId, unitId: unitId, label: label});
     }
     const handleApplyLabels = (selectedRowKeys, labels) => {
-        selectedRowKeys.forEach((val, idx) => val
-            ? labels.forEach((label) => handleAddLabel(idx+1, label))
+        Object.keys(selectedRowKeys).forEach((key) => key
+            ? labels.forEach((label) => handleAddLabel(key, label))
             : {});
     };
     const handlePurgeLabels = (selectedRowKeys, labels) => {
-        selectedRowKeys.forEach((val, idx) => val
-            ? labels.forEach((label) => handleRemoveLabel(idx+1, label))
+        Object.keys(selectedRowKeys).forEach((key) => key
+            ? labels.forEach((label) => handleRemoveLabel(key, label))
             : {});
     }
     const rows = 

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -47,15 +47,15 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         onRemoveUnitLabel({sortingId: sorting.sortingId, unitId: unitId, label: label});
     }
     const handleApplyLabels = (selectedRowKeys, labels) => {
-        Object.keys(selectedRowKeys).forEach((key) => key
+        Object.keys(selectedRowKeys).forEach((key) => selectedRowKeys[key]
             ? labels.forEach((label) => handleAddLabel(key, label))
             : {});
     };
     const handlePurgeLabels = (selectedRowKeys, labels) => {
-        Object.keys(selectedRowKeys).forEach((key) => key
+        Object.keys(selectedRowKeys).forEach((key) => selectedRowKeys[key]
             ? labels.forEach((label) => handleRemoveLabel(key, label))
             : {});
-    }
+    };
     const rows = 
         sorting.sortingInfo.unit_ids.map(unitId => ({
         key: unitId,


### PR DESCRIPTION
This fixes the bug we were talking about this morning regarding 0-indexed or 1-indexed unit arrays, and should also deal with the case of units/other inputs to NiceTable which have non-consecutive or not-strictly-numeric ids.

I also fixed a bug that was preventing the '0' from displaying in cases where the unit is actually labeled 0.