### PR TITLE
Cross correlograms

### DIFF
--- a/src/components/NiceTable.js
+++ b/src/components/NiceTable.js
@@ -16,7 +16,6 @@ const NiceTable = ({
 }) => {
 
     const selectedRowKeysObj = {};
-    console.log(`Selected row keys: ${JSON.stringify(selectedRowKeys)}`)
     Object.keys(selectedRowKeys).forEach((key) => {selectedRowKeysObj[key] = selectedRowKeys[key]});
     const handleClickRow = (key) => {
         if (!onSelectedRowKeysChanged || false) return;
@@ -29,10 +28,6 @@ const NiceTable = ({
         }
         else if (selectionMode === 'multiple') {
             // todo: write this logic. Note, we'll need to also pass in the event to get the ctrl/shift modifiers
-            // I actually think the UI expectation for a checkbox is such that we shouldn't worry about modifier
-            // keys--just treat any click like a ctrl-click. (I would also, if possible, use radio buttons
-            // in place of checkboxes for the row selection in single-select mode.)
-            console.log(`Contents of selected row keys obj: ${JSON.stringify(selectedRowKeysObj)}`);
             onSelectedRowKeysChanged(
                 Object.keys(selectedRowKeysObj)
                     // eslint-disable-next-line eqeqeq

--- a/src/components/NiceTable.js
+++ b/src/components/NiceTable.js
@@ -11,12 +11,13 @@ const NiceTable = ({
     onEditRow,
     editRowLabel,
     selectionMode='none', // none, single, multiple
-    selectedRowKeys,
+    selectedRowKeys={},
     onSelectedRowKeysChanged
 }) => {
 
     const selectedRowKeysObj = {};
-    selectedRowKeys && selectedRowKeys.forEach((val, idx) => {selectedRowKeysObj[idx+1] = val});
+    console.log(`Selected row keys: ${JSON.stringify(selectedRowKeys)}`)
+    Object.keys(selectedRowKeys).forEach((key) => {selectedRowKeysObj[key] = selectedRowKeys[key]});
     const handleClickRow = (key) => {
         if (!onSelectedRowKeysChanged || false) return;
         if (selectionMode === 'single') {
@@ -31,6 +32,7 @@ const NiceTable = ({
             // I actually think the UI expectation for a checkbox is such that we shouldn't worry about modifier
             // keys--just treat any click like a ctrl-click. (I would also, if possible, use radio buttons
             // in place of checkboxes for the row selection in single-select mode.)
+            console.log(`Contents of selected row keys obj: ${JSON.stringify(selectedRowKeysObj)}`);
             onSelectedRowKeysChanged(
                 Object.keys(selectedRowKeysObj)
                     // eslint-disable-next-line eqeqeq
@@ -93,6 +95,8 @@ const NiceTable = ({
 };
 
 const makeCell = (x) => {
+    // eslint-disable-next-line eqeqeq
+    if (x == 0) return x;  // !'0' is true, but we shouldn't null out actual 0s
     if (!x) return '';
     if (typeof(x) == "object") {
         if (x.element) return x.element;

--- a/src/components/SortingInfoView.js
+++ b/src/components/SortingInfoView.js
@@ -1,50 +1,72 @@
 import React from 'react'
 
-const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked }) => {
+const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, curation, styling }) => {
     const si = sortingInfo;
     if (!si) return <div>No sorting info found</div>;
 
     const labelStyle = {
         'minWidth': '200px',
-        'display': 'inline-block'
+        'fontWeight': 'bold',
+        'padding': '7px 5px 7px 5px'
     }
     
     const focusedStyle = {
         'fontWeight': 'bold',
         color: '#4287f5',
-        'backgroundColor': 'white'
+        'backgroundColor': 'white',
     }
     
     const selectedStyle = {
         'fontWeight': 'bold',
         color: 'blue',
-        'backgroundColor': 'white'
+        'backgroundColor': 'white',
     }
     
     const unselectedStyle = {
         'fontWeight': 'normal',
         color: 'black',
+        'backgroundColor': 'white',
+    }
+
+    const unitIdStyle = {
+        'paddingRight': '13px',
+        'paddingTop': '10px'
+    }
+
+    const labelListStyle = {
+        'paddingRight': '3px',
+        'color': '#333333',
         'backgroundColor': 'white'
     }
     
     const SortingViewDiv = ({ unit_ids }) => {
         return (
-            <div style={{ width: 600 }}>
-                <span style={labelStyle}>Unit IDs</span>
-                <span>{unit_ids.map((unitId, idx, ary) => clickabilize(unitId, idx, ary))} </span>
+            <div style={styling}>
+                <div style={labelStyle}>Unit IDs</div>
+                {unit_ids.map((unitId, idx, ary) => clickabilize(unitId, idx, ary))}
             </div>
         )
     }
         
     function clickabilize(unitId, idx, ary) {
         return (
-            <span
+            <div
                 key={unitId}
                 style={(isSelected && isSelected(unitId)) ? (isFocused(unitId)? focusedStyle: selectedStyle) : unselectedStyle}
                 onClick={(event) => onUnitClicked(unitId, event)}
             >
-                {unitId}{idx === ary.length - 1 ? '' : ', '}
-            </span>
+                <span style={unitIdStyle}>{unitId}</span>
+                <span>
+                    {((curation[unitId] || {}).labels || [])
+                        .map((label) => {
+                            return (
+                                <span style={labelListStyle}>
+                                    {label}&nbsp;
+                                </span>
+                            )
+                        })}
+                </span>
+            </div>
         );
     }
 

--- a/src/components/SortingInfoView.js
+++ b/src/components/SortingInfoView.js
@@ -12,17 +12,22 @@ const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, cu
     
     const focusedStyle = {
         'fontWeight': 'bold',
-        color: '#4287f5',
-        'backgroundColor': 'white',
+        'border': 'solid 1px #4287f5',
+        'backgroundColor': '#c0d9ff',
+        'color': 'black'
+        // color: '#4287f5',
+        // 'backgroundColor': 'white',
     }
     
     const selectedStyle = {
+        'border': 'solid 1px blue',
         'fontWeight': 'bold',
-        color: 'blue',
-        'backgroundColor': 'white',
+        color: 'black',
+        'backgroundColor': '#b5d1ff',
     }
     
     const unselectedStyle = {
+        'border': 'transparent 1px solid',
         'fontWeight': 'normal',
         color: 'black',
         'backgroundColor': 'white',
@@ -33,10 +38,19 @@ const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, cu
         'paddingTop': '10px'
     }
 
-    const labelListStyle = {
+    const focusedLabelStyle = {
+        'paddingRight': '3px',
+        'color': '#333333'
+    }
+
+    const selectedLabelStyle = {
+        'paddingRight': '3px',
+        'color': '#333333'
+    }
+
+    const unselectedLabelStyle = {
         'paddingRight': '3px',
         'color': '#333333',
-        'backgroundColor': 'white'
     }
     
     const SortingViewDiv = ({ unit_ids }) => {
@@ -47,12 +61,28 @@ const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, cu
             </div>
         )
     }
+
+    const GetUnitStyle = (unitId) => {
+        return ((isSelected && isSelected(unitId))
+                ? (isFocused && isFocused(unitId)
+                    ? focusedStyle
+                    : selectedStyle)
+                : unselectedStyle);
+    }
+
+    const GetLabelsStyle = (unitId) => {
+        return ((isSelected && isSelected(unitId))
+                ? ((isFocused && isFocused(unitId))
+                    ? focusedLabelStyle
+                    : selectedLabelStyle)
+                : unselectedLabelStyle);
+    }
         
     function clickabilize(unitId, idx, ary) {
         return (
             <div
                 key={unitId}
-                style={(isSelected && isSelected(unitId)) ? (isFocused(unitId)? focusedStyle: selectedStyle) : unselectedStyle}
+                style={GetUnitStyle(unitId)}
                 onClick={(event) => onUnitClicked(unitId, event)}
             >
                 <span style={unitIdStyle}>{unitId}</span>
@@ -60,7 +90,7 @@ const SortingInfoView = ({ sortingInfo, isSelected, isFocused, onUnitClicked, cu
                     {((curation[unitId] || {}).labels || [])
                         .map((label) => {
                             return (
-                                <span style={labelListStyle}>
+                                <span style={GetLabelsStyle(unitId)}>
                                     {label}&nbsp;
                                 </span>
                             )

--- a/src/containers/SortingView.js
+++ b/src/containers/SortingView.js
@@ -86,6 +86,24 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo, onAddUni
     setFocusedUnitId(focusedUnitId);
   }
 
+  const sidebarWidth = '200px'
+
+  const sidebarStyle = {
+    'width': sidebarWidth,
+    'height': '100%',
+    'position': 'absolute',
+    'zIndex': 1,
+    'top': 150,
+    'left': 0,
+    'overflowX': 'hidden',
+    'paddingTop': '20px',
+    'paddingLeft': '20px'
+  }
+
+  const contentWrapperStyle = {
+    'marginLeft': sidebarWidth
+  }
+
   if (!sorting) {
     return <h3>{`Sorting not found: ${sortingId}`}</h3>
   }
@@ -101,10 +119,12 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo, onAddUni
             isSelected={isSelected}
             isFocused={isFocused}
             onUnitClicked={handleUnitClicked}
+            curation={sorting.unitCuration || {}}
+            styling={sidebarStyle}
           />
         )
       }
-      <div>
+      <div style={contentWrapperStyle}>
         {
           pluginComponentsList.map(PluginComponent => {
             const config = PluginComponent.sortingViewPlugin;

--- a/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
+++ b/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
@@ -22,8 +22,13 @@ def genplot_crosscorrelogram(sorting_object, x_unit_id, y_unit_id, plot_edge_siz
     S = le.LabboxEphysSortingExtractor(sorting_object)
 
     f = plt.figure(figsize=(plot_edge_size, plot_edge_size))
-    _plot_crosscorrelogram(ax=plt.gca(), sorting=S, unit_id1=x_unit_id,
-        unit_id2=y_unit_id,window_size_msec=50, bin_size_msec=1)
+
+    if x_unit_id != y_unit_id:
+        _plot_crosscorrelogram(ax=plt.gca(), sorting=S, unit_id1=x_unit_id,
+            unit_id2=y_unit_id,window_size_msec=50, bin_size_msec=1)
+    else:
+        _plot_autocorrelogram(ax=plt.gca(), sorting=S, unit_id=x_unit_id,
+            window_size_msec=50, bin_size_msec=1)
     return mpld3.fig_to_dict(f)
 
 def _plot_correlogram(*, ax, bin_counts, bins, wid, title='', color=None):

--- a/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
+++ b/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
@@ -14,6 +14,18 @@ def genplot_autocorrelogram(sorting_object, unit_id):
     _plot_autocorrelogram(ax=plt.gca(), sorting=S, unit_id=unit_id, window_size_msec=50, bin_size_msec=1)
     return mpld3.fig_to_dict(f)
 
+@hi.function('genplot_crosscorrelogram', '0.1.0')
+def genplot_crosscorrelogram(sorting_object, x_unit_id, y_unit_id, plot_edge_size):
+    import matplotlib.pyplot as plt, mpld3
+    import labbox_ephys as le
+
+    S = le.LabboxEphysSortingExtractor(sorting_object)
+
+    f = plt.figure(figsize=(plot_edge_size, plot_edge_size))
+    _plot_crosscorrelogram(ax=plt.gca(), sorting=S, unit_id1=x_unit_id,
+        unit_id2=y_unit_id,window_size_msec=50, bin_size_msec=1)
+    return mpld3.fig_to_dict(f)
+
 def _plot_correlogram(*, ax, bin_counts, bins, wid, title='', color=None):
     kk = 1000
     ax.bar(x=(bins-wid/2)*kk, height=bin_counts,

--- a/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
+++ b/src/pluginComponents/AutoCorrelograms/genplot_autocorrelogram.py
@@ -9,9 +9,11 @@ def genplot_autocorrelogram(sorting_object, unit_id):
     import labbox_ephys as le
 
     S = le.LabboxEphysSortingExtractor(sorting_object)
+    bins, bin_counts, bin_size = _get_correlogram_data(sorting=S, unit_id1=unit_id,
+        window_size_msec=50, bin_size_msec=1)
 
     f = plt.figure(figsize=(2, 2))
-    _plot_autocorrelogram(ax=plt.gca(), sorting=S, unit_id=unit_id, window_size_msec=50, bin_size_msec=1)
+    _plot_correlogram(ax=plt.gca(), bin_counts=bin_counts, bins=bins, wid=bin_size, color='gray')
     return mpld3.fig_to_dict(f)
 
 @hi.function('genplot_crosscorrelogram', '0.1.0')
@@ -20,35 +22,13 @@ def genplot_crosscorrelogram(sorting_object, x_unit_id, y_unit_id, plot_edge_siz
     import labbox_ephys as le
 
     S = le.LabboxEphysSortingExtractor(sorting_object)
-
     f = plt.figure(figsize=(plot_edge_size, plot_edge_size))
 
-    if x_unit_id != y_unit_id:
-        _plot_crosscorrelogram(ax=plt.gca(), sorting=S, unit_id1=x_unit_id,
-            unit_id2=y_unit_id,window_size_msec=50, bin_size_msec=1)
-    else:
-        _plot_autocorrelogram(ax=plt.gca(), sorting=S, unit_id=x_unit_id,
-            window_size_msec=50, bin_size_msec=1)
+    bins, bin_counts, bin_size = _get_correlogram_data(sorting=S, unit_id1=x_unit_id,
+        unit_id2=y_unit_id, window_size_msec=50, bin_size_msec=1)
+    _plot_correlogram(ax=plt.gca(), bin_counts=bin_counts, bins=bins, wid=bin_size, color='gray')
+
     return mpld3.fig_to_dict(f)
-
-@hi.function('gendata_crosscorrelogram', '0.1.0')
-def gendata_crosscorrelogram(sorting_object, x_unit_id, y_unit_id, plot_edge_size):
-    import labbox_ephys as le
-
-    S = le.LabboxEphysSortingExtractor(sorting_object)
-
-    if x_unit_id != y_unit_id:
-        bins, bin_counts, bin_size_sec = _get_crosscorrelogram_data(
-            sorting=S, unit_id1=x_unit_id,
-            unit_id2=y_unit_id,window_size_msec=50, bin_size_msec=1
-        )
-        return dict(
-            bins=bins,
-            bin_counts=bin_counts,
-            bin_size_sec=bin_size_sec
-        )
-    else:
-        raise Exception('needs to be implemented')
 
 def _plot_correlogram(*, ax, bin_counts, bins, wid, title='', color=None):
     kk = 1000
@@ -58,49 +38,32 @@ def _plot_correlogram(*, ax, bin_counts, bins, wid, title='', color=None):
     ax.set_xticks([bins[0]*kk, bins[len(bins)//2]*kk, bins[-1]*kk])
     # ax.set_yticks([])
 
-
-def _plot_autocorrelogram(ax, sorting, unit_id, window_size_msec, bin_size_msec):
-    times = sorting.get_unit_spike_train(unit_id=unit_id)
+def _get_correlogram_data(*, sorting, unit_id1, unit_id2=None, window_size_msec, bin_size_msec):
+    auto = unit_id2 is None or unit_id2 == unit_id1
+    
+    times = sorting.get_unit_spike_train(unit_id=unit_id1)
+    window_size = window_size_msec / 1000
+    bin_size = bin_size_msec / 1000
     labels = np.ones(times.shape, dtype=np.int32)
-    window_size = window_size_msec / 1000
-    bin_size = bin_size_msec / 1000
+    cluster_ids = [1]
+    if not auto:
+        times2 = sorting.get_unit_spike_train(unit_id=unit_id2)
+        times = np.concatenate((times, times2))
+        labels = np.concatenate((labels, np.ones(times2.shape, dtype=np.int32) *2 ))
+        cluster_ids.append(2)
+        inds = np.argsort(times)
+        times = times[inds]
+        labels = labels[inds]
     C = compute_correlograms(
         spike_times=times/sorting.get_sampling_frequency(),
         spike_clusters=labels,
-        cluster_ids=[1],
+        cluster_ids=cluster_ids,
         bin_size=bin_size,
         window_size=window_size,
         sample_rate=sorting.get_sampling_frequency(),
         symmetrize=True
     )
     bins = np.linspace(- window_size / 2, window_size / 2, C.shape[2])
-    _plot_correlogram(ax=ax, bin_counts=C[0, 0, :], bins=bins, wid=bin_size, color='gray')
-
-def _get_crosscorrelogram_data(sorting, unit_id1, unit_id2, window_size_msec, bin_size_msec):
-    times1 = sorting.get_unit_spike_train(unit_id=unit_id1)
-    times2 = sorting.get_unit_spike_train(unit_id=unit_id2)
-    times = np.concatenate((times1, times2))
-    labels = np.concatenate(
-        (np.ones(times1.shape, dtype=np.int32)*1, np.ones(times2.shape, dtype=np.int32)*2))
-    inds = np.argsort(times)
-    times = times[inds]
-    labels = labels[inds]
-    window_size = window_size_msec / 1000
-    bin_size = bin_size_msec / 1000
-    C = compute_correlograms(
-        spike_times=times/sorting.get_sampling_frequency(),
-        spike_clusters=labels,
-        cluster_ids=[1, 2],
-        bin_size=bin_size,
-        window_size=window_size,
-        sample_rate=sorting.get_sampling_frequency(),
-        symmetrize=True
-    )
-    bins = np.linspace(- window_size / 2, window_size / 2, C.shape[2])
-    bin_counts = C[0, 1, :]
+    bin_counts = C[0, 0, :] if auto else C[0, 1, :]
     bin_size_sec = bin_size_msec / 1000
     return bins, bin_counts, bin_size_sec
-
-def _plot_crosscorrelogram(ax, sorting, unit_id1, unit_id2, window_size_msec, bin_size_msec):
-    bins, bin_counts, bin_size = _get_crosscorrelogram_data(sorting, unit_id1, unit_id2, window_size_msec, bin_size_msec)
-    _plot_correlogram(ax=ax, bin_counts=bin_counts, bins=bins, wid=bin_size, color='gray')

--- a/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
+++ b/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
@@ -18,7 +18,7 @@ const CrossCorrelograms = ({ size, sorting, recording, isSelected, isFocused, on
 
     const n = chosenPlots.length || 0;
 
-    const computeLayout = (marginInPx, maxSize = 500) => {
+    const computeLayout = (marginInPx, maxSize = 800) => {
         // we need to fit a square of side length n elements into the wrapper's width.
         if (n < 2) return;
         // note adjacent margins will collapse, and we don't care about vertical length
@@ -28,8 +28,6 @@ const CrossCorrelograms = ({ size, sorting, recording, isSelected, isFocused, on
         // Solve for plotWidth = (width - margin*(n+1))/n.
         // And we can't have fractional pixels, so round down.
         const plotWidth = Math.min(maxSize, Math.floor((size.width - marginInPx*(n + 1))/n));
-
-        alert(`Computed side width is ${plotWidth} for ${n} elements and ${size.width} total space`);
         return plotWidth;
     }
 
@@ -46,6 +44,41 @@ const CrossCorrelograms = ({ size, sorting, recording, isSelected, isFocused, on
     const pairs = makePairs();
     const plotWidth = computeLayout(plotMargin);
     const rowBounds = [...Array(pairs.length).keys()].filter(i => i % n === 0);
+
+    const renderRow = ( pairs, plotWidth ) => {
+        return (
+            <Grid>
+                {
+                    pairs.map((pair) => (
+                        <Grid key={pair.xkey + '-' + pair.ykey} item
+                                style={{ 'paddingBottom': '25px',
+                                    'marginBottom': '50px'}}>
+                            <div
+                            >
+                                <div style={{ 'textAlign': 'center', 'fontWeight': 'bold' }}>
+                                    <div>{pair.xkey + ' vs ' + pair.ykey}</div>
+                                </div>
+                                {/* <Box display="flex" width={plotWidth + "px"} height={plotWidth + 'px'}
+                                >
+                                    <CircularProgress />
+                                </Box> */}
+                                <MatplotlibPlot
+                                    functionName='genplot_crosscorrelogram'
+                                    functionArgs={{
+                                        sorting_object: sorting.sortingObject,
+                                        x_unit_id: pair.xkey,
+                                        y_unit_id: pair.ykey,
+                                        plot_edge_size: (plotWidth/100)
+                                    }}
+                                />
+                            </div>
+                        </Grid>
+                    ))
+                }
+            </Grid>
+        );
+    }
+
     return (
         <div style={{'width': '100%'}} id={myId}>
             <Grid container>
@@ -55,29 +88,6 @@ const CrossCorrelograms = ({ size, sorting, recording, isSelected, isFocused, on
             </Grid>
             <Button onClick={() => handleUpdateChosenPlots()}>Update selections</Button>
         </div>
-    );
-}
-
-const renderRow = ( pairs, plotWidth ) => {
-    return (
-        <Grid>
-            {
-                pairs.map((pair) => (
-                    <Grid key={pair.xkey + '-' + pair.ykey} item>
-                        <div
-                        >
-                            <div style={{ 'textAlign': 'center' }}>
-                                <div>{pair.xkey + ' vs ' + pair.ykey}</div>
-                            </div>
-                            <Box display="flex" width={plotWidth + "px"} height={plotWidth + 'px'}
-                            >
-                                <CircularProgress />
-                            </Box>
-                        </div>
-                    </Grid>
-                ))
-            }
-        </Grid>
     );
 }
 

--- a/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
+++ b/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
@@ -1,13 +1,69 @@
-import React from 'react'
-import sampleSortingViewProps from '../common/sampleSortingViewProps'
+import React, { useState } from 'react';
+import MatplotlibPlot from '../../components/MatplotlibPlot';
+import { Grid } from '@material-ui/core';
+import { Button } from '@material-ui/core';
+import { Box, CircularProgress } from '@material-ui/core'; // this should go away once we're doing actual plots
+import sampleSortingViewProps from '../common/sampleSortingViewProps';
 
 const CrossCorrelograms = ({ sorting, recording, isSelected, isFocused, onUnitClicked }) => {
+    const [chosenPlots, setChosenPlots] = useState([]);
+    const myId =  Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+
+    const handleUpdateChosenPlots = () => {
+        setChosenPlots(sorting.sortingInfo.unit_ids.filter((key) => isSelected(key)));
+    };
+
+    const computeLayout = (frameId, marginInPx) => {
+        const width = document.getElementById(frameId).offsetWidth;
+        // we need to fit a square of side length n elements into the wrapper's width.
+        const n = chosenPlots.length;
+        if (n < 2) return;
+        // note adjacent margins will collapse, and we don't care about vertical length
+        // (the user can scroll). So: horizontal space taken is:
+        // width = n*plotWidth + 2*margin (2 outer margins) + (n-1)*margin (gutters between plots)
+        // width = margin*(n+1) + plotWidth * n
+        // Solve for plotWidth = (width - margin*(n+1))/n.
+        // And we can't have fractional pixels, so round down.
+        const plotWidth = Math.floor((width - marginInPx*(n + 1))/n);
+
+        return plotWidth;
+    }
+
+    const makePairs = () => {
+        return chosenPlots.reduce((list, xItem) => {
+            return list.concat(chosenPlots.map((yItem) => {
+                return {xkey: xItem, ykey: yItem}
+            }))
+        }, []);
+    }
+
     return (
-        <div>Crosscorrelograms.</div>
+        <div style={{'width': '100%'}} id={myId}>
+            <Grid container>
+                {
+                    sorting.sortingInfo.unit_ids.map(unitId => (
+                        <Grid key={unitId} item>
+                            <div
+                            >
+                                <div style={{ 'textAlign': 'center' }}>
+                                    <div></div>
+                                </div>
+                                <Box display="flex" width={computeLayout(myId, 1)}
+                                >
+                                    <CircularProgress />
+                                </Box>
+                            </div>
+                        </Grid>
+                    ))
+                }
+            </Grid>
+            <Button onClick={() => handleUpdateChosenPlots()}>Update selections</Button>
+            <Button onClick={() => {alert(`Pairs: ${JSON.stringify(makePairs())}`)}}>Show Layout</Button>
+        </div>
     );
 }
 
-const label = 'Crosscorrelograms'
+const label = 'Cross-Correlograms'
 
 CrossCorrelograms.sortingViewPlugin = {
     label: label

--- a/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
+++ b/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
+import { withSize } from 'react-sizeme';
+// import sizeMe from 'react-sizeme';
 import MatplotlibPlot from '../../components/MatplotlibPlot';
 import { Grid } from '@material-ui/core';
 import { Button } from '@material-ui/core';
 import { Box, CircularProgress } from '@material-ui/core'; // this should go away once we're doing actual plots
 import sampleSortingViewProps from '../common/sampleSortingViewProps';
 
-const CrossCorrelograms = ({ sorting, recording, isSelected, isFocused, onUnitClicked }) => {
+const CrossCorrelograms = ({ size, sorting, recording, isSelected, isFocused, onUnitClicked }) => {
+    const plotMargin = 2; // in pixels
     const [chosenPlots, setChosenPlots] = useState([]);
     const myId =  Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
@@ -13,10 +16,10 @@ const CrossCorrelograms = ({ sorting, recording, isSelected, isFocused, onUnitCl
         setChosenPlots(sorting.sortingInfo.unit_ids.filter((key) => isSelected(key)));
     };
 
-    const computeLayout = (frameId, marginInPx) => {
-        const width = document.getElementById(frameId).offsetWidth;
+    const n = chosenPlots.length || 0;
+
+    const computeLayout = (marginInPx, maxSize = 500) => {
         // we need to fit a square of side length n elements into the wrapper's width.
-        const n = chosenPlots.length;
         if (n < 2) return;
         // note adjacent margins will collapse, and we don't care about vertical length
         // (the user can scroll). So: horizontal space taken is:
@@ -24,11 +27,14 @@ const CrossCorrelograms = ({ sorting, recording, isSelected, isFocused, onUnitCl
         // width = margin*(n+1) + plotWidth * n
         // Solve for plotWidth = (width - margin*(n+1))/n.
         // And we can't have fractional pixels, so round down.
-        const plotWidth = Math.floor((width - marginInPx*(n + 1))/n);
+        const plotWidth = Math.min(maxSize, Math.floor((size.width - marginInPx*(n + 1))/n));
 
+        alert(`Computed side width is ${plotWidth} for ${n} elements and ${size.width} total space`);
         return plotWidth;
     }
 
+    // pairs are objects of the form '{ xkey: unitId, ykey: unitId }'
+    // This function should return a list of the pairs, in row-major order.
     const makePairs = () => {
         return chosenPlots.reduce((list, xItem) => {
             return list.concat(chosenPlots.map((yItem) => {
@@ -37,29 +43,41 @@ const CrossCorrelograms = ({ sorting, recording, isSelected, isFocused, onUnitCl
         }, []);
     }
 
+    const pairs = makePairs();
+    const plotWidth = computeLayout(plotMargin);
+    const rowBounds = [...Array(pairs.length).keys()].filter(i => i % n === 0);
     return (
         <div style={{'width': '100%'}} id={myId}>
             <Grid container>
                 {
-                    sorting.sortingInfo.unit_ids.map(unitId => (
-                        <Grid key={unitId} item>
-                            <div
-                            >
-                                <div style={{ 'textAlign': 'center' }}>
-                                    <div></div>
-                                </div>
-                                <Box display="flex" width={computeLayout(myId, 1)}
-                                >
-                                    <CircularProgress />
-                                </Box>
-                            </div>
-                        </Grid>
-                    ))
+                    rowBounds.map((start) => renderRow(pairs.slice(start, start + n), plotWidth))
                 }
             </Grid>
             <Button onClick={() => handleUpdateChosenPlots()}>Update selections</Button>
-            <Button onClick={() => {alert(`Pairs: ${JSON.stringify(makePairs())}`)}}>Show Layout</Button>
         </div>
+    );
+}
+
+const renderRow = ( pairs, plotWidth ) => {
+    return (
+        <Grid>
+            {
+                pairs.map((pair) => (
+                    <Grid key={pair.xkey + '-' + pair.ykey} item>
+                        <div
+                        >
+                            <div style={{ 'textAlign': 'center' }}>
+                                <div>{pair.xkey + ' vs ' + pair.ykey}</div>
+                            </div>
+                            <Box display="flex" width={plotWidth + "px"} height={plotWidth + 'px'}
+                            >
+                                <CircularProgress />
+                            </Box>
+                        </div>
+                    </Grid>
+                ))
+            }
+        </Grid>
     );
 }
 
@@ -74,4 +92,14 @@ CrossCorrelograms.prototypeViewPlugin = {
     props: sampleSortingViewProps()
 }
 
-export default CrossCorrelograms
+// export default CrossCorrelograms;
+const exportedComponent = withSize()(CrossCorrelograms);
+exportedComponent.sortingViewPlugin = {
+    label: label
+}
+exportedComponent.prototypeViewPlugin = {
+    label: label,
+    props: sampleSortingViewProps()
+}
+
+export default exportedComponent;

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -29,10 +29,11 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         return 0;
     });
 
-    const selectedRowKeys = sorting.sortingInfo.unit_ids.map((id) => isSelected(id));
+    const selectedRowKeys = sorting.sortingInfo.unit_ids
+        .reduce((obj, id) => ({...obj, [id]: isSelected(id)}), {});
     const handleSelectedRowKeysChanged = (keys) => {
         onSelectedUnitIdsChanged(
-            keys.reduce((o, key) => Object.assign(o, {[key]: true}), {})
+            keys.reduce((o, key) => ({...o, [key]: true}), {})
         );
     }
     const getLabelsForUnitId = unitId => {
@@ -46,13 +47,13 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         onRemoveUnitLabel({sortingId: sorting.sortingId, unitId: unitId, label: label});
     }
     const handleApplyLabels = (selectedRowKeys, labels) => {
-        selectedRowKeys.forEach((val, idx) => val
-            ? labels.forEach((label) => handleAddLabel(idx+1, label))
+        Object.keys(selectedRowKeys).forEach((key) => key
+            ? labels.forEach((label) => handleAddLabel(key, label))
             : {});
     };
     const handlePurgeLabels = (selectedRowKeys, labels) => {
-        selectedRowKeys.forEach((val, idx) => val
-            ? labels.forEach((label) => handleRemoveLabel(idx+1, label))
+        Object.keys(selectedRowKeys).forEach((key) => key
+            ? labels.forEach((label) => handleRemoveLabel(key, label))
             : {});
     }
     const rows = 

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -47,15 +47,15 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         onRemoveUnitLabel({sortingId: sorting.sortingId, unitId: unitId, label: label});
     }
     const handleApplyLabels = (selectedRowKeys, labels) => {
-        Object.keys(selectedRowKeys).forEach((key) => key
+        Object.keys(selectedRowKeys).forEach((key) => selectedRowKeys[key]
             ? labels.forEach((label) => handleAddLabel(key, label))
             : {});
     };
     const handlePurgeLabels = (selectedRowKeys, labels) => {
-        Object.keys(selectedRowKeys).forEach((key) => key
+        Object.keys(selectedRowKeys).forEach((key) => selectedRowKeys[key]
             ? labels.forEach((label) => handleRemoveLabel(key, label))
             : {});
-    }
+    };
     const rows = 
         sorting.sortingInfo.unit_ids.map(unitId => ({
         key: unitId,

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -99,7 +99,7 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
     );
 }
 
-const label = 'Units'
+const label = 'Units Table'
 
 Units.sortingViewPlugin = {
     label: label


### PR DESCRIPTION
These are now implemented. Further styling is likely to be required.

Outstanding Issues:

 - **Major:** Existing plots do not re-size/re-render when updating the selection. So, if you add to an existing selection and click the update button, the result is several plots at the old size and several plots at the new (perforce smaller) size, which also breaks the rows. I'm sure there's a way to force rerender on update, and we should do that.

 - **Unsure:** Selections disappear on collapsing the cross-correlograms accordion, and must be re-selected. I don't know if this is a big deal or not.

 - **Minor:** When larger numbers of plots are displayed, the bottom caption is clipped by the border of the content below. Maybe I need to increase the padding on something, or give a little extra slack to account for the label div?

 - **Minor**: It'd be nice to tighten up the spacing between the plot label and the plots themselves, as in the multiple-row layout, it would be too easy to read the caption as referring to the plot above it rather than the one below it.

 - **Existential:** Should we even be bothering to resize these plots based on how many will fit? It seems like this would make them easier to read, but it can also lead to a need for vertical scrolling.

I've opened this as a PR right now because while there are some issues that should still be resolved, it's in good enough shape to show off under controlled conditions.