### PR TITLE
Tweaks to firing rate display. Updated renamed React component.

### DIFF
--- a/src/components/Prototypes.js
+++ b/src/components/Prototypes.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails } from '@material-ui/core';
+import { Accordion, AccordionSummary, AccordionDetails } from '@material-ui/core';
 import * as pluginComponents from '../pluginComponents';
 
 const pluginComponentsList = Object.values(pluginComponents);
@@ -31,14 +31,14 @@ const Prototypes = () => {
 
 const Expandable = ({ label, children }) => {
   return (
-    <ExpansionPanel TransitionProps={{ unmountOnExit: true }}>
-      <ExpansionPanelSummary>
+    <Accordion TransitionProps={{ unmountOnExit: true }}>
+      <AccordionSummary>
         {label}
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         {children}
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   )
 }
 

--- a/src/containers/SortingView.js
+++ b/src/containers/SortingView.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import SortingInfoView from '../components/SortingInfoView';
-import { CircularProgress, ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails } from '@material-ui/core';
+import { CircularProgress, Accordion, AccordionSummary, AccordionDetails } from '@material-ui/core';
 import { withRouter } from 'react-router-dom';
 import { setSortingInfo, addUnitLabel, removeUnitLabel } from '../actions';
 import { createHitherJob } from '../hither';
@@ -161,14 +161,14 @@ const SortingView = ({ sortingId, sorting, recording, onSetSortingInfo, onAddUni
 
 const Expandable = ({ label, children }) => {
   return (
-    <ExpansionPanel TransitionProps={{ unmountOnExit: true }}>
-      <ExpansionPanelSummary>
+    <Accordion TransitionProps={{ unmountOnExit: true }}>
+      <AccordionSummary>
         {label}
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         {children}
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   )
 }
 

--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -138,11 +138,11 @@ const Units = ({ sorting, recording, isSelected, isFocused, onUnitClicked, onAdd
         },
         {
             key: 'eventCount',
-            label: 'Number of Events',
+            label: 'Num. events',
         },
         {
             key: 'firingRate',
-            label: 'Firing Rate',
+            label: 'Firing rate (Hz)',
         }
     ];
     // TODO: define additional columns such as: num. events, avg. firing rate, snr, ...

--- a/src/pluginComponents/Units/units.py
+++ b/src/pluginComponents/Units/units.py
@@ -2,11 +2,15 @@ import hither as hi
 
 @hi.function('get_firing_data', '0.1.0')
 def get_firing_data(sorting_object, recording_object):
+    from decimal import Decimal
     S, R = get_structure(sorting_object, recording_object)
     elapsed = R.get_num_frames()/R.get_sampling_frequency()
     ids = S.get_unit_ids()
     train = [S.get_unit_spike_train(id).size for id in ids]
-    keyedCount = dict(zip([id for id in ids], [{'count': t, 'rate': t / elapsed} for t in train]))
+    keyedCount = dict(zip(
+        [id for id in ids],
+        [{'count': t,
+          'rate': f"{Decimal(t / elapsed).quantize(Decimal('.01'))}"} for t in train]))
     return keyedCount
 
 


### PR DESCRIPTION
Tweaked names of two columns in firing rate data and rounded to 2 decimal places (ensuring that trailing zeroes are included). The latter also involved doing the division as Decimal and quantizing the result, so I broke up the map function line spacing a little bit so it's easier to read.

As a drive-by, I also got a warning that React's `ExpansionPanel` element family has been renamed to `Accordion`, so I made that update in the codebase.