### PR TITLE
Fixes overselection issue and resorts layout to follow matrix indexing

### DIFF
--- a/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
+++ b/src/pluginComponents/CrossCorrelograms/CrossCorrelograms.js
@@ -8,12 +8,17 @@ import sampleSortingViewProps from '../common/sampleSortingViewProps';
 
 
 const CrossCorrelograms = ({ size, sorting, recording, selectedUnitIds }) => {
+    const filteredIds = Object.fromEntries(
+        Object.keys(selectedUnitIds).filter(k => selectedUnitIds[k])
+        .filter(id => sorting.sortingInfo.unit_ids.includes(parseInt(id)))
+        .map(id => [id, true]));
+
     const plotMargin = 2; // in pixels
     const [chosenPlots, setChosenPlots] = useState([]);
     const myId =  Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 
     const handleUpdateChosenPlots = () => {
-        setChosenPlots(Object.keys(selectedUnitIds)
+        setChosenPlots(Object.keys(filteredIds)
             .map((x) => parseInt(x))
             .filter(x => !isNaN(x)));
     };
@@ -36,8 +41,8 @@ const CrossCorrelograms = ({ size, sorting, recording, selectedUnitIds }) => {
     // pairs are objects of the form '{ xkey: unitId, ykey: unitId }'
     // This function should return a list of the pairs, in row-major order.
     const makePairs = () => {
-        return chosenPlots.reduce((list, xItem) => {
-            return list.concat(chosenPlots.map((yItem) => {
+        return chosenPlots.reduce((list, yItem) => {
+            return list.concat(chosenPlots.map((xItem) => {
                 return {xkey: xItem, ykey: yItem}
             }))
         }, []);


### PR DESCRIPTION
The way shift-select is implemented, it will include any unit id that falls between the lower and higher numbered unit ids (inclusive). This isn't a problem for most display, because we can just ignore the selection status of any data that doesn't exist, but it's a problem for cross-correlograms, because that code was using the entire selection set to make its Cartesian product of pairs to display. For filtered (non-contiguous) unit data, this can mean displaying a bunch of pairs that aren't even part of the curation, resulting in at best, useless garbage, and at worst, useless garbage that takes a long time to compute.

I added a simple filter to stop this from happening, and while I was modifying the file I also swapped the ordering of the pair-building function so that it would follow the indexing conventions that were originally intended (so the row would appear first in the pairs, not the column).