### PR TITLE
Add isi violations metric.

### DIFF
--- a/src/pluginComponents/Units/Units.js
+++ b/src/pluginComponents/Units/Units.js
@@ -61,7 +61,8 @@ const Units = ({ sorting, recording, selectedUnitIds, extensionsConfig,
         return 0;
     });
 
-    const fetchMetric = useCallback(async (metric = {metricName: '', hitherFnName: '', hitherConfig: {}}) => {
+    const fetchMetric = useCallback(async (metric = {metricName: '', hitherFnName: '',
+                                                    metricFnParams: {}, hitherConfig: {}}) => {
         const name = metric.metricName;
 
         if (name in metrics) {
@@ -75,7 +76,8 @@ const Units = ({ sorting, recording, selectedUnitIds, extensionsConfig,
             const data = await createHitherJob(metric.hitherFnName,
                 {
                     sorting_object: sorting.sortingObject,
-                    recording_object: recording.recordingObject
+                    recording_object: recording.recordingObject,
+                    configuration: metric.metricFnParams
                 },
                 {
                     ...metric.hitherConfig,

--- a/src/pluginComponents/Units/UnitsTable.js
+++ b/src/pluginComponents/Units/UnitsTable.js
@@ -49,7 +49,7 @@ const MetricCell = React.memo(({error = '', data, PayloadComponent}) => {
     if (error !== '') {
         return (<TableCell><span>{`Error: ${error}`}</span></TableCell>);
     }
-    if (!data || data === '') {
+    if (data === null || data === '') { // 0 is a valid value!!
         return (<TableCell><LinearProgress style={{'width': '60%'}}/></TableCell>);
     } else {
         return (
@@ -88,8 +88,8 @@ const UnitsTable = ({metricPlugins = [], units = [], metrics, selectedUnitIds = 
                                         <MetricCell
                                             key = {metricName + '_' + unitId}
                                             data = {((metric['data']) === '' || 
-                                                    !metric['data'][unitId])
-                                                ? NaN : metric['data'][unitId]}
+                                                    !(unitId in metric['data']))
+                                                ? null : metric['data'][unitId]}
                                             error = {metric['error']}
                                             PayloadComponent = {mp}
                                         />

--- a/src/pluginComponents/Units/UnitsTable.js
+++ b/src/pluginComponents/Units/UnitsTable.js
@@ -7,7 +7,7 @@ const getLabelsForUnitId = (unitId, sorting) => {
     return (unitCuration[unitId] || {}).labels || [];
 }
 
-const HeaderRow = React.memo(({pluginLabels}) => {
+const HeaderRow = React.memo(({plugins}) => {
     return (
         <TableHead>
             <TableRow>
@@ -15,11 +15,13 @@ const HeaderRow = React.memo(({pluginLabels}) => {
                 <TableCell key="_unitIds"><span>Unit ID</span></TableCell>
                 <TableCell key="_labels"><span>Labels</span></TableCell>
                 {
-                    pluginLabels.map(plugin => (
-                        <TableCell key={plugin + '_header'}>
-                            <span>{plugin}</span>
-                        </TableCell>
-                    ))
+                    plugins.map(plugin => {
+                        return (
+                            <TableCell key={plugin.columnLabel + '_header'}>
+                                <span title={plugin.tooltip}>{plugin.columnLabel}</span>
+                            </TableCell>
+                        );
+                    })
                 }
             </TableRow>
         </TableHead>
@@ -65,7 +67,7 @@ const UnitsTable = ({metricPlugins = [], units = [], metrics, selectedUnitIds = 
     return (
         <Table className="NiceTable">
             <HeaderRow 
-                pluginLabels={metricPlugins.map(mp => mp['columnLabel'])}
+                plugins={metricPlugins}
             />
             <TableBody>
                 {

--- a/src/pluginComponents/Units/metricPlugins/EventCount.js
+++ b/src/pluginComponents/Units/metricPlugins/EventCount.js
@@ -9,6 +9,7 @@ const EventCount = React.memo(({record}) => {
 EventCount.metricName = 'EventCount';
 EventCount.columnLabel = 'Num. events';
 EventCount.hitherFnName = 'get_firing_data';
+EventCount.metricFnParams = {};
 EventCount.hitherConfig = {
     auto_substitute_file_objects: true,
     wait: true,

--- a/src/pluginComponents/Units/metricPlugins/EventCount.js
+++ b/src/pluginComponents/Units/metricPlugins/EventCount.js
@@ -8,6 +8,7 @@ const EventCount = React.memo(({record}) => {
 
 EventCount.metricName = 'EventCount';
 EventCount.columnLabel = 'Num. events';
+EventCount.tooltip = 'Number of firing events';
 EventCount.hitherFnName = 'get_firing_data';
 EventCount.metricFnParams = {};
 EventCount.hitherConfig = {

--- a/src/pluginComponents/Units/metricPlugins/FiringRate.js
+++ b/src/pluginComponents/Units/metricPlugins/FiringRate.js
@@ -8,6 +8,7 @@ const FiringRate = React.memo(({record = {}}) => {
 
 FiringRate.metricName = 'FiringRate';
 FiringRate.columnLabel = 'Firing rate (Hz)';
+FiringRate.tooltip = 'Average events per second';
 FiringRate.hitherFnName = 'get_firing_data';
 FiringRate.metricFnParams = {};
 FiringRate.hitherConfig = {

--- a/src/pluginComponents/Units/metricPlugins/FiringRate.js
+++ b/src/pluginComponents/Units/metricPlugins/FiringRate.js
@@ -9,6 +9,7 @@ const FiringRate = React.memo(({record = {}}) => {
 FiringRate.metricName = 'FiringRate';
 FiringRate.columnLabel = 'Firing rate (Hz)';
 FiringRate.hitherFnName = 'get_firing_data';
+FiringRate.metricFnParams = {};
 FiringRate.hitherConfig = {
     auto_substitute_file_objects: true,
     wait: true,

--- a/src/pluginComponents/Units/metricPlugins/IsiViolations.js
+++ b/src/pluginComponents/Units/metricPlugins/IsiViolations.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const IsiViolations = React.memo(({record = {}}) => {
+    return (
+        <span>{record}</span>
+    );
+});
+
+IsiViolations.metricName = 'IsiViolations';
+IsiViolations.columnLabel = 'ISI Violation rate';
+IsiViolations.hitherFnName = 'get_isi_violation_rates';
+IsiViolations.metricFnParams = {
+    'isi_threshold_msec': 2.5
+    // need to sort out how to pass unit ids list?
+};
+IsiViolations.hitherConfig = {
+    auto_substitute_file_objects: true,
+    wait: true,
+    useClientCache: true,
+    hither_config: {
+        use_job_cache: true
+    },
+    job_handler_name: 'partition3'
+}
+
+IsiViolations.metricPlugin = {
+    development: false
+}
+
+export default IsiViolations;

--- a/src/pluginComponents/Units/metricPlugins/IsiViolations.js
+++ b/src/pluginComponents/Units/metricPlugins/IsiViolations.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const IsiViolations = React.memo(({record = {}}) => {
     return (
-        <span>{record}</span>
+        <span>{record.toFixed(6)}</span>
     );
 });
 

--- a/src/pluginComponents/Units/metricPlugins/IsiViolations.js
+++ b/src/pluginComponents/Units/metricPlugins/IsiViolations.js
@@ -2,12 +2,13 @@ import React from 'react';
 
 const IsiViolations = React.memo(({record = {}}) => {
     return (
-        <span>{record.toFixed(6)}</span>
+        <span>{record.toFixed(4)}</span>
     );
 });
 
 IsiViolations.metricName = 'IsiViolations';
-IsiViolations.columnLabel = 'ISI Violation rate';
+IsiViolations.columnLabel = 'ISI viol.';
+IsiViolations.tooltip = 'ISI violation rate';
 IsiViolations.hitherFnName = 'get_isi_violation_rates';
 IsiViolations.metricFnParams = {
     'isi_threshold_msec': 2.5

--- a/src/pluginComponents/Units/metricPlugins/index.js
+++ b/src/pluginComponents/Units/metricPlugins/index.js
@@ -1,2 +1,3 @@
 export {default as EventCount} from './EventCount';
 export {default as FiringRate} from './FiringRate';
+export {default as IsiViolations} from './IsiViolations';

--- a/src/pluginComponents/Units/metricPlugins/isi_violations.py
+++ b/src/pluginComponents/Units/metricPlugins/isi_violations.py
@@ -1,0 +1,26 @@
+import hither as hi
+
+@hi.function('get_isi_violation_rates', '0.1.0')
+@hi.container('docker://magland/labbox-ephys-processing:0.2.18')
+@hi.local_modules(['../../../../python/labbox_ephys'])
+def get_isi_violation_rates(sorting_object, recording_object, configuration={}):
+    import labbox_ephys as le
+    import spikemetrics as sm
+    S = le.LabboxEphysSortingExtractor(sorting_object)
+    R = le.LabboxEphysRecordingExtractor(recording_object)
+
+    samplerate = R.get_sampling_frequency()
+#    duration_sec = R.get_num_frames() / samplerate
+
+    isi_threshold_msec = configuration.get('isi_threshold_msec', 2.5)
+    unit_ids = configuration.get('unit_ids', S.get_unit_ids())
+
+    ret = {}
+    for id in unit_ids:
+        spike_train = S.get_unit_spike_train(unit_id=id)
+        ret[str(id)], _ = sm.metrics.isi_violations( #_ is total violations
+            spike_train=spike_train,
+            duration=R.get_num_frames(),
+            isi_threshold=isi_threshold_msec / 1000 * samplerate
+        )
+    return ret

--- a/src/pluginComponents/Units/units.py
+++ b/src/pluginComponents/Units/units.py
@@ -3,7 +3,7 @@ import hither as hi
 @hi.function('get_firing_data', '0.1.2')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
-def get_firing_data(sorting_object, recording_object):
+def get_firing_data(sorting_object, recording_object, configuration):
     from decimal import Decimal
     S, R = get_structure(sorting_object, recording_object)
     elapsed = R.get_num_frames()/R.get_sampling_frequency()

--- a/src/pluginComponents/__init__.py
+++ b/src/pluginComponents/__init__.py
@@ -4,5 +4,6 @@ from .MatplotlibTest.test_mpl import test_mpl
 
 from .AutoCorrelograms.genplot_autocorrelogram import fetch_correlogram_plot_data
 from .Units.units import get_firing_data, get_structure
+from .Units.metricPlugins.isi_violations import get_isi_violation_rates
 
 from .AverageWaveforms.genplot_average_waveform import fetch_average_waveform_plot_data


### PR DESCRIPTION
Confirmed that we can use additional kwargs through a configuration object in the individual metric plugin. Fixed a few bugs in the sentinel values that were causing display problems/bad logic when the value to be displayed actually was 0.

Confirmed that values are displayed when this is run against an actual dataset (used allen 419112 from the spike workshop).

Possible TODO: We may want to set a maximum decimal precision on the output, so it looks cleaner.