### PR TITLE
split genplot_average_waveforms into 2 steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Then:
 
 ```bash
 # On Linux:
-labbox-launcher run magland/labbox-ephys:0.3.14 --docker_run_opts "--net host" --data $LABBOX_EPHYS_DATA_DIR
+labbox-launcher run magland/labbox-ephys:0.3.15 --docker_run_opts "--net host" --data $LABBOX_EPHYS_DATA_DIR
 
 # On MacOS:
-labbox-launcher run magland/labbox-ephys:0.3.14 --docker_run_opts "-p 15310:15310 -p 15308:15308" --data $LABBOX_EPHYS_DATA_DIR
+labbox-launcher run magland/labbox-ephys:0.3.15 --docker_run_opts "-p 15310:15310 -p 15308:15308" --data $LABBOX_EPHYS_DATA_DIR
 ```
 
 ### View in browser

--- a/devel/kube/deployment.yml
+++ b/devel/kube/deployment.yml
@@ -20,7 +20,7 @@ spec:
             claimName: labbox-ephys-pv-claim
       containers:
       - name: labbox-ephys
-        image: magland/labbox-ephys:0.3.14
+        image: magland/labbox-ephys:0.3.15
         imagePullPolicy: Always
         env:
         - name: HOME

--- a/devel/test_prepare_snippets_h5.py
+++ b/devel/test_prepare_snippets_h5.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import spikeextractors as se
+import hither as hi
+import labbox_ephys as le
+
+# this is how the hither functions get registered
+import labbox_ephys as le
+thisdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(f'{thisdir}/../src')
+import pluginComponents
+pluginComponents # just keep the linter happy - we only need to import pluginComponents to register the hither functions
+
+def main():
+    recording_object = {"data":{"geom":[[1,0],[2,0],[3,0],[4,0]],"params":{"samplerate":30000,"spike_sign":-1},"raw":"sha1dir://fb52d510d2543634e247e0d2d1d4390be9ed9e20.synth_magland/datasets_noise10_K10_C4/001_synth/raw.mda"},"recording_format":"mda"}
+    sorting_object = {"data":{"firings":"sha1dir://fb52d510d2543634e247e0d2d1d4390be9ed9e20.synth_magland/datasets_noise10_K10_C4/001_synth/firings_true.mda","samplerate":30000},"sorting_format":"mda"}
+    recording = le.LabboxEphysRecordingExtractor(recording_object)
+    sorting = le.LabboxEphysSortingExtractor(sorting_object)
+    prepare_snippets_h5 = hi.get_function('prepare_snippets_h5')
+    h5_path = prepare_snippets_h5.run(sorting_object=sorting_object, recording_object=recording_object).wait()
+    print(h5_path)
+
+if __name__ == '__main__':
+    main()

--- a/devel/test_prepare_snippets_h5_large.py
+++ b/devel/test_prepare_snippets_h5_large.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import spikeextractors as se
+import hither as hi
+import labbox_ephys as le
+import kachery_p2p as kp
+
+# this is how the hither functions get registered
+import labbox_ephys as le
+thisdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(f'{thisdir}/../src')
+import pluginComponents
+pluginComponents # just keep the linter happy - we only need to import pluginComponents to register the hither functions
+
+def main():
+    # Sorting: cortexlab-single-phase-3 Curated (good units) for cortexlab-single-phase-3 (full)
+    recording_object = kp.load_object('sha1://8b222e25bc4d9c792e4490ca322b5338e0795596/cortexlab-single-phase-3.json')
+    sorting_object = {"sorting_format":"h5_v1","data":{"h5_path":"sha1://68029d0eded8ca7d8f95c16dea81318966ae9b55/sorting.h5?manifest=12b0d8e37c7050a6fe636d4c16ed143bbd5dab0c"}}
+    recording = le.LabboxEphysRecordingExtractor(recording_object)
+    sorting = le.LabboxEphysSortingExtractor(sorting_object)
+    prepare_snippets_h5 = hi.get_function('prepare_snippets_h5')
+    h5_path = prepare_snippets_h5.run(sorting_object=sorting_object, recording_object=recording_object).wait()
+    print(h5_path)
+
+if __name__ == '__main__':
+    main()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labbox-ephys",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/python/labbox_ephys/__init__.py
+++ b/python/labbox_ephys/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.14"
+__version__ = "0.3.15"
 
 from .extractors import LabboxEphysRecordingExtractor, LabboxEphysSortingExtractor
 from .extractors import MdaRecordingExtractor, MdaSortingExtractor

--- a/src/pluginComponents/AverageWaveforms/AverageWaveforms.js
+++ b/src/pluginComponents/AverageWaveforms/AverageWaveforms.js
@@ -11,7 +11,7 @@ const AverageWaveforms = ({ sorting, recording, selectedUnitIds, focusedUnitId,
             selections={selectedUnitIds}
             focus={focusedUnitId}
             onUnitClicked={onUnitClicked}
-            dataFunctionName={'fetch_average_waveform_plot_data'}
+            dataFunctionName={'createjob_fetch_average_waveform_plot_data'}
             dataFunctionArgsCallback={(unitId) => ({
                 sorting_object: sorting.sortingObject,
                 recording_object: recording.recordingObject,
@@ -22,8 +22,7 @@ const AverageWaveforms = ({ sorting, recording, selectedUnitIds, focusedUnitId,
             plotComponentArgsCallback={(unitId) => ({
                 id: 'plot-'+unitId
             })}
-            useJobCache={true}
-            jobHandlerName="partition2"
+            newHitherJobMethod={true}
         />
     );
 }

--- a/src/pluginComponents/AverageWaveforms/SubsampledSortingExtractor.py
+++ b/src/pluginComponents/AverageWaveforms/SubsampledSortingExtractor.py
@@ -1,0 +1,49 @@
+from typing import Union
+import numpy as np
+import spikeextractors as se
+
+class SubsampledSortingExtractor(se.SortingExtractor):
+    # method: 'random', 'truncate'
+    def __init__(self, parent_sorting, *, max_events_per_unit: Union[int, None]=None, method='random'):
+        se.SortingExtractor.__init__(self)
+        self._parent_sorting = parent_sorting
+        self._subsampled_spike_trains_by_unit = {}
+        unit_ids = parent_sorting.get_unit_ids()
+        for unit_id in unit_ids:
+            if max_events_per_unit is not None:
+                st = parent_sorting.get_unit_spike_train(unit_id=unit_id)
+                if len(st) > max_events_per_unit:
+                    if method == 'random':
+                        indices = np.sort(np.random.RandomState(seed=0).choice(np.arange(len(st)), size=max_events_per_unit, replace=False))
+                    elif method == 'truncate':
+                        indices = np.arange(max_events_per_unit)
+                    else:
+                        raise Exception('Unexpected method in SubsampledSortingExtractor')
+                    self._subsampled_spike_trains_by_unit[int(unit_id)] = st[indices]
+                else:
+                    self._subsampled_spike_trains_by_unit[int(unit_id)] = None
+            else:
+                self._subsampled_spike_trains_by_unit[int(unit_id)] = None
+        
+    def make_serialized_dict(self):
+        # this is necessary because the base class implementation
+        # seems to have a bug where it asks for imported_module.__version__, which may not be defined
+        return None
+
+    def get_unit_ids(self):
+        return self._parent_sorting.get_unit_ids()
+
+    def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
+        st2 = self._subsampled_spike_trains_by_unit[int(unit_id)]
+        if st2 is None:
+            return self._parent_sorting.get_unit_spike_train(unit_id=unit_id, start_frame=start_frame, end_frame=end_frame)
+        if start_frame is None and end_frame is None:
+            return st2
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = np.Inf
+        return st2[(start_frame <= st2) & (st2 < end_frame)]
+
+    def get_sampling_frequency(self):
+        return self._parent_sorting.get_sampling_frequency()

--- a/src/pluginComponents/AverageWaveforms/find_unit_neighborhoods.py
+++ b/src/pluginComponents/AverageWaveforms/find_unit_neighborhoods.py
@@ -1,0 +1,26 @@
+from typing import Dict
+import numpy as np
+
+def find_unit_neighborhoods(recording, peak_channels_by_unit, max_neighborhood_size) -> Dict[int, list]:
+    channel_ids = recording.get_channel_ids()
+    locations_by_channel = {}
+    for ii, channel_id in enumerate(channel_ids):
+        locations_by_channel[int(channel_id)] = np.array(recording.get_channel_property(channel_id=channel_id, property_name='location'))
+    neighborhoods = {}
+    for unit_id in peak_channels_by_unit.keys():
+        if len(channel_ids) <= max_neighborhood_size:
+            neighborhood_channel_ids = channel_ids
+        else:
+            peak_channel_id = peak_channels_by_unit[int(unit_id)]
+            peak_location = locations_by_channel[int(peak_channel_id)]
+            distances = []
+            for channel_id in channel_ids:
+                loc = locations_by_channel[int(channel_id)]
+                dist = np.linalg.norm(np.array(loc) - np.array(peak_location))
+                distances.append(dist)
+            sorted_indices = np.argsort(distances)
+            neighborhood_channel_ids = []
+            for ii in range(min(max_neighborhood_size, len(channel_ids))):
+                neighborhood_channel_ids.append(int(channel_ids[sorted_indices[ii]]))
+        neighborhoods[int(unit_id)] = neighborhood_channel_ids
+    return neighborhoods

--- a/src/pluginComponents/AverageWaveforms/find_unit_peak_channels.py
+++ b/src/pluginComponents/AverageWaveforms/find_unit_peak_channels.py
@@ -1,0 +1,27 @@
+import numpy as np
+import spikeextractors as se
+from .get_unit_waveforms import get_unit_waveforms
+from .SubsampledSortingExtractor import SubsampledSortingExtractor
+
+def find_unit_peak_channels(recording, sorting, unit_ids):
+    # Use the first part of the recording to estimate the peak channels
+    sorting_shortened = SubsampledSortingExtractor(parent_sorting=sorting, max_events_per_unit=20, method='truncate')
+    max_time = 0
+    for unit_id in sorting_shortened.get_unit_ids():
+        st = sorting_shortened.get_unit_spike_train(unit_id=unit_id)
+        max_time = max(max_time, np.max(st))
+    recording_shortened = se.SubRecordingExtractor(parent_recording=recording, start_frame=0, end_frame=max_time + 1)
+    unit_waveforms = get_unit_waveforms(
+        recording=recording_shortened,
+        sorting=sorting_shortened,
+        unit_ids=unit_ids,
+        channel_ids_by_unit=None,
+        snippet_len=(10, 10)
+    )
+    channel_ids = recording.get_channel_ids()
+    peak_channels = {}
+    for ii, unit_id in enumerate(unit_ids):
+        average_waveform = np.median(unit_waveforms[ii], axis=0)
+        peak_channel_index = int(np.argmax(np.max(average_waveform, axis=1) - np.min(average_waveform, axis=1)))
+        peak_channels[unit_id] = int(channel_ids[peak_channel_index])
+    return peak_channels

--- a/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
+++ b/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
@@ -1,8 +1,13 @@
+from typing import Dict
 import hither as hi
 import numpy as np
 import kachery as ka
 import spikeextractors as se
 import spiketoolkit as st
+from .get_unit_waveforms import get_unit_waveforms
+from .SubsampledSortingExtractor import SubsampledSortingExtractor
+from .find_unit_neighborhoods import find_unit_neighborhoods
+from .find_unit_peak_channels import find_unit_peak_channels
 
 @hi.function('createjob_fetch_average_waveform_plot_data', '')
 def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting_object, unit_id):
@@ -19,7 +24,7 @@ def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting
             unit_id=unit_id
         )
 
-@hi.function('prepare_snippets_h5', '0.1.3')
+@hi.function('prepare_snippets_h5', '0.2.2')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
 def prepare_snippets_h5(recording_object, sorting_object):
@@ -29,14 +34,34 @@ def prepare_snippets_h5(recording_object, sorting_object):
     sorting = le.LabboxEphysSortingExtractor(sorting_object)
     unit_ids = sorting.get_unit_ids()
     samplerate = sorting.get_sampling_frequency()
-    unit_waveforms = st.postprocessing.get_unit_waveforms(
+    
+    # Use this optimized function rather than spiketoolkit's version
+    # for efficiency with long recordings and/or many channels, units or spikes
+    # we should submit this to the spiketoolkit project as a PR
+    # but it may be tricky because this version has fewer options
+
+    max_events_per_unit = 500
+    max_neighborhood_size = 12
+
+    sorting_subsampled = SubsampledSortingExtractor(parent_sorting=sorting, max_events_per_unit=max_events_per_unit, method='random')
+    peak_channels_by_unit = find_unit_peak_channels(recording=recording, sorting=sorting, unit_ids=unit_ids)
+    channel_ids_by_unit = find_unit_neighborhoods(recording=recording, peak_channels_by_unit=peak_channels_by_unit, max_neighborhood_size=max_neighborhood_size)
+
+    unit_waveforms = get_unit_waveforms(
         recording=recording,
-        sorting=sorting,
+        sorting=sorting_subsampled,
         unit_ids=unit_ids,
-        ms_before=1,
-        ms_after=1.5,
-        max_spikes_per_unit=500
+        channel_ids_by_unit=channel_ids_by_unit,
+        snippet_len=(50, 80)
     )
+    # unit_waveforms = st.postprocessing.get_unit_waveforms(
+    #     recording=recording,
+    #     sorting=sorting,
+    #     unit_ids=unit_ids,
+    #     ms_before=1,
+    #     ms_after=1.5,
+    #     max_spikes_per_unit=500
+    # )
     with hi.TemporaryDirectory() as tmpdir:
         save_path = tmpdir + '/snippets.h5'
         with h5py.File(save_path, 'w') as f:
@@ -47,11 +72,11 @@ def prepare_snippets_h5(recording_object, sorting_object):
                 x = sorting.get_unit_spike_train(unit_id=unit_id)
                 f.create_dataset(f'unit_spike_trains/{unit_id}', data=np.array(x).astype(np.float64))
                 f.create_dataset(f'unit_waveforms/{unit_id}/waveforms', data=unit_waveforms[ii].astype(np.float32))
-                f.create_dataset(f'unit_waveforms/{unit_id}/channel_ids', data=recording.get_channel_ids())
+                f.create_dataset(f'unit_waveforms/{unit_id}/channel_ids', data=np.array(channel_ids_by_unit[int(unit_id)]).astype(int))
         return ka.store_file(save_path)
                 
 
-@hi.function('fetch_average_waveform_plot_data', '0.1.14')
+@hi.function('fetch_average_waveform_plot_data', '0.2.1')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
 def fetch_average_waveform_plot_data(snippets_h5, unit_id):
@@ -63,6 +88,7 @@ def fetch_average_waveform_plot_data(snippets_h5, unit_id):
         unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
         unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
         unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+        print(unit_waveforms_channel_ids)
     
     average_waveform = np.median(unit_waveforms, axis=0)
     channel_maximums = np.max(np.abs(average_waveform), axis=1)
@@ -70,11 +96,11 @@ def fetch_average_waveform_plot_data(snippets_h5, unit_id):
     maxchan_id = unit_waveforms_channel_ids[maxchan_index]
 
     return dict(
-        channel_id=maxchan_id,
-        average_waveform=average_waveform[maxchan_id, :].tolist()
+        channel_id=int(maxchan_id),
+        average_waveform=average_waveform[maxchan_index, :].astype(float).tolist()
     )
 
-@hi.function('old_fetch_average_waveform_plot_data', '0.1.13')
+@hi.function('old_fetch_average_waveform_plot_data', '0.1.14')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
 def old_fetch_average_waveform_plot_data(recording_object, sorting_object, unit_id):
@@ -109,5 +135,5 @@ def old_fetch_average_waveform_plot_data(recording_object, sorting_object, unit_
 
     return dict(
         channel_id=maxchan_id,
-        average_waveform=average_waveform[maxchan_id, :].tolist()
+        average_waveform=average_waveform[maxchan_index, :].tolist()
     )

--- a/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
+++ b/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
@@ -24,7 +24,7 @@ def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting
             unit_id=unit_id
         )
 
-@hi.function('prepare_snippets_h5', '0.2.2')
+@hi.function('prepare_snippets_h5', '0.2.3')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
 def prepare_snippets_h5(recording_object, sorting_object):

--- a/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
+++ b/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
@@ -4,10 +4,80 @@ import kachery as ka
 import spikeextractors as se
 import spiketoolkit as st
 
-@hi.function('fetch_average_waveform_plot_data', '0.1.13')
+@hi.function('createjob_fetch_average_waveform_plot_data', '')
+def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting_object, unit_id):
+    jh = labbox.get_job_handler('partition2')
+    jc = labbox.get_default_job_cache()
+    with hi.Config(
+        job_cache=jc,
+        job_handler=jh,
+        container=jh.is_remote
+    ):
+        snippets_h5 = prepare_snippets_h5.run(recording_object=recording_object, sorting_object=sorting_object)
+        return fetch_average_waveform_plot_data.run(
+            snippets_h5=snippets_h5,
+            unit_id=unit_id
+        )
+
+@hi.function('prepare_snippets_h5', '0.1.3')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
-def fetch_average_waveform_plot_data(recording_object, sorting_object, unit_id):
+def prepare_snippets_h5(recording_object, sorting_object):
+    import h5py
+    import labbox_ephys as le
+    recording = le.LabboxEphysRecordingExtractor(recording_object)
+    sorting = le.LabboxEphysSortingExtractor(sorting_object)
+    unit_ids = sorting.get_unit_ids()
+    samplerate = sorting.get_sampling_frequency()
+    unit_waveforms = st.postprocessing.get_unit_waveforms(
+        recording=recording,
+        sorting=sorting,
+        unit_ids=unit_ids,
+        ms_before=1,
+        ms_after=1.5,
+        max_spikes_per_unit=500
+    )
+    with hi.TemporaryDirectory() as tmpdir:
+        save_path = tmpdir + '/snippets.h5'
+        with h5py.File(save_path, 'w') as f:
+            f.create_dataset('unit_ids', data=np.array(unit_ids).astype(np.int32))
+            f.create_dataset('sampling_frequency', data=np.array([samplerate]).astype(np.float64))
+            f.create_dataset('channel_ids', data=np.array(recording.get_channel_ids()))
+            for ii, unit_id in enumerate(unit_ids):
+                x = sorting.get_unit_spike_train(unit_id=unit_id)
+                f.create_dataset(f'unit_spike_trains/{unit_id}', data=np.array(x).astype(np.float64))
+                f.create_dataset(f'unit_waveforms/{unit_id}/waveforms', data=unit_waveforms[ii].astype(np.float32))
+                f.create_dataset(f'unit_waveforms/{unit_id}/channel_ids', data=recording.get_channel_ids())
+        return ka.store_file(save_path)
+                
+
+@hi.function('fetch_average_waveform_plot_data', '0.1.14')
+@hi.container('docker://magland/labbox-ephys-processing:0.2.18')
+@hi.local_modules(['../../../python/labbox_ephys'])
+def fetch_average_waveform_plot_data(snippets_h5, unit_id):
+    import h5py
+    h5_path = ka.load_file(snippets_h5)
+    with h5py.File(h5_path, 'r') as f:
+        unit_ids = np.array(f.get('unit_ids'))
+        sampling_frequency = np.array(f.get('sampling_frequency'))[0]
+        unit_spike_train = np.array(f.get(f'unit_spike_trains/{unit_id}'))
+        unit_waveforms = np.array(f.get(f'unit_waveforms/{unit_id}/waveforms'))
+        unit_waveforms_channel_ids = np.array(f.get(f'unit_waveforms/{unit_id}/channel_ids'))
+    
+    average_waveform = np.median(unit_waveforms, axis=0)
+    channel_maximums = np.max(np.abs(average_waveform), axis=1)
+    maxchan_index = np.argmax(channel_maximums)
+    maxchan_id = unit_waveforms_channel_ids[maxchan_index]
+
+    return dict(
+        channel_id=maxchan_id,
+        average_waveform=average_waveform[maxchan_id, :].tolist()
+    )
+
+@hi.function('old_fetch_average_waveform_plot_data', '0.1.13')
+@hi.container('docker://magland/labbox-ephys-processing:0.2.18')
+@hi.local_modules(['../../../python/labbox_ephys'])
+def old_fetch_average_waveform_plot_data(recording_object, sorting_object, unit_id):
     import labbox_ephys as le
     R = le.LabboxEphysRecordingExtractor(recording_object)
     S = le.LabboxEphysSortingExtractor(sorting_object)

--- a/src/pluginComponents/AverageWaveforms/get_unit_waveforms.py
+++ b/src/pluginComponents/AverageWaveforms/get_unit_waveforms.py
@@ -93,7 +93,7 @@ def get_unit_waveforms(
 
     num_channels = recording.get_num_channels()
     num_frames = recording.get_num_frames()
-    num_bytes_per_chunk = 10 * 1000 * 1000 # ? how to choose this
+    num_bytes_per_chunk = 1000 * 1000 * 1000 # ? how to choose this
     num_bytes_per_frame = num_channels * 2
     chunk_size = num_bytes_per_chunk / num_bytes_per_frame
     padding_size = 100 + snippet_len[0] + snippet_len[1] # a bit excess padding

--- a/src/pluginComponents/AverageWaveforms/get_unit_waveforms.py
+++ b/src/pluginComponents/AverageWaveforms/get_unit_waveforms.py
@@ -1,0 +1,137 @@
+import spikeextractors as se
+import numpy as np
+
+def _extract_snippet_from_traces(
+    traces,
+    start_frame,
+    end_frame,
+    channel_indices
+):
+    if (0 <= start_frame) and (end_frame <= traces.shape[1]):
+        x = traces[:, start_frame:end_frame]
+    else:
+        # handle edge cases
+        x = np.zeros((traces.shape[0], end_frame - start_frame), dtype=traces.dtype)
+        i1 = int(max(0, start_frame))
+        i2 = int(min(traces.shape[1], end_frame))
+        x[:, (i1 - start_frame):(i2 - start_frame)] = traces[:, i1:i2]
+    if channel_indices is not None:
+        x = x[channel_indices, :]
+    return x
+
+def _get_unit_waveforms_for_chunk(
+    recording,
+    sorting,
+    frame_offset,
+    unit_ids,
+    snippet_len,
+    channel_ids_by_unit
+):
+    # chunks are chosen small enough so that all traces can be loaded into memory
+    traces = recording.get_traces()
+
+    unit_waveforms = []
+    for unit_id in unit_ids:
+        times0 = sorting.get_unit_spike_train(unit_id=unit_id)
+        if channel_ids_by_unit is not None:
+            channel_ids = channel_ids_by_unit[unit_id]
+            all_channel_ids = recording.get_channel_ids()
+            channel_indices = [
+                np.array(all_channel_ids).tolist().index(ch_id)
+                for ch_id in channel_ids
+            ]
+            len_channel_indices = len(channel_indices)
+        else:
+            channel_indices = None
+            len_channel_indices = traces.shape[0]
+        # num_channels x len_of_one_snippet
+        snippets = [
+            _extract_snippet_from_traces(
+                traces,
+                start_frame=frame_offset + int(t) - snippet_len[0],
+                end_frame=frame_offset + int(t) + snippet_len[1],
+                channel_indices=channel_indices
+            )
+            for t in times0
+        ]
+        if len(snippets) > 0:
+            unit_waveforms.append(
+                # len(times0) x num_channels_in_nbhd[unit_id] x len_of_one_snippet
+                np.stack(snippets)
+            )
+        else:
+            unit_waveforms.append(
+                np.zeros((0, len_channel_indices, snippet_len[0] + snippet_len[1]), dtype=traces.dtype)
+            )
+    return unit_waveforms
+
+def _divide_recording_into_time_chunks(num_frames, chunk_size, padding_size):
+    chunks = []
+    ii = 0
+    while ii < num_frames:
+        ii2 = int(min(ii + chunk_size, num_frames))
+        chunks.append(dict(
+            istart=ii,
+            iend=ii2,
+            istart_with_padding=int(max(0, ii - padding_size)),
+            iend_with_padding=int(min(num_frames, ii2 + padding_size))
+        ))
+        ii = ii2
+    return chunks
+
+def get_unit_waveforms(
+    recording,
+    sorting,
+    unit_ids,
+    channel_ids_by_unit,
+    snippet_len
+):
+    if not isinstance(snippet_len, list) and not isinstance(snippet_len, tuple):
+        b = int(snippet_len / 2)
+        a = int(snippet_len) - b
+        snippet_len = [a, b]
+
+    num_channels = recording.get_num_channels()
+    num_frames = recording.get_num_frames()
+    num_bytes_per_chunk = 10 * 1000 * 1000 # ? how to choose this
+    num_bytes_per_frame = num_channels * 2
+    chunk_size = num_bytes_per_chunk / num_bytes_per_frame
+    padding_size = 100 + snippet_len[0] + snippet_len[1] # a bit excess padding
+    chunks = _divide_recording_into_time_chunks(
+        num_frames=num_frames,
+        chunk_size=chunk_size,
+        padding_size=padding_size
+    )
+    all_unit_waveforms = [[] for ii in range(len(unit_ids))]
+    for chunk in chunks:
+        # chunk: {istart, iend, istart_with_padding, iend_with_padding} # include padding
+        recording_chunk = se.SubRecordingExtractor(
+            parent_recording=recording,
+            start_frame=chunk['istart_with_padding'],
+            end_frame=chunk['iend_with_padding']
+        )
+        # note that the efficiency of this operation may need improvement (really depends on sorting extractor implementation)
+        sorting_chunk = se.SubSortingExtractor(
+            parent_sorting=sorting,
+            start_frame=chunk['istart'],
+            end_frame=chunk['iend']
+        )
+        # num_events_in_chunk x num_channels_in_nbhd[unit_id] x len_of_one_snippet
+        unit_waveforms = _get_unit_waveforms_for_chunk(
+            recording=recording_chunk,
+            sorting=sorting_chunk,
+            frame_offset=chunk['istart'] - chunk['istart_with_padding'], # just the padding size (except 0 for first chunk)
+            unit_ids=unit_ids,
+            snippet_len=snippet_len,
+            channel_ids_by_unit=channel_ids_by_unit
+        )
+        for i_unit, x in enumerate(unit_waveforms):
+            all_unit_waveforms[i_unit].append(x)
+    
+    # concatenate the results over the chunks
+    unit_waveforms = [
+        # tot_num_events_for_unit x num_channels_in_nbhd[unit_id] x len_of_one_snippet
+        np.concatenate(all_unit_waveforms[i_unit], axis=0)
+        for i_unit in range(len(unit_ids))
+    ]
+    return unit_waveforms


### PR DESCRIPTION
split genplot_average_waveforms into 2 steps

I split the genplot_average_waveforms into a preprocessing step (creating an .hdf5 file with a subsampling of snippets) and a computation script. The idea is that this preprocessing is also used by other metrics. In fact, the same preprocessing job is used by each average_waveform job across all of the units. Hither handles this nicely so that the job is only queued once.

TODO: the creating of the snippets file needs to made more efficient for large problems (long recordings, many channels, many units, many spikes) -- need to look at the innards of the spiketoolkit implementation