### PR TITLE
Convert frames to msec for spike waveforms.

### DIFF
--- a/src/pluginComponents/AverageWaveforms/AverageWaveform_ReactVis.js
+++ b/src/pluginComponents/AverageWaveforms/AverageWaveform_ReactVis.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { XYPlot, XAxis, YAxis, VerticalBarSeries, LineSeries } from 'react-vis';
+import { XYPlot, XAxis, YAxis, LineSeries } from 'react-vis';
 
 const AverageWaveform_rv = (boxSize, plotData, argsObject = {id: 0}) => {
     // plotData will be an array of [x-vals], [y-vals], and x-stepsize.
@@ -15,7 +15,8 @@ const AverageWaveform_rv = (boxSize, plotData, argsObject = {id: 0}) => {
         return <div />;
     }
 
-    const data = plotData.average_waveform.map((v, ii) => ({x: ii, y: v}));
+    const factor = 1000 / plotData.sampling_frequency
+    const data = plotData.average_waveform.map((v, ii) => ({x: ii*factor, y: v}));
 
     const xAxisLabel = 'dt (msec)'
 
@@ -32,7 +33,6 @@ const AverageWaveform_rv = (boxSize, plotData, argsObject = {id: 0}) => {
                 <LineSeries
                     data={data}
                 />
-                {/* <VerticalBarSeries data={data} /> */}
                 <XAxis />
                 <YAxis />
             </XYPlot>

--- a/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
+++ b/src/pluginComponents/AverageWaveforms/genplot_average_waveform.py
@@ -6,7 +6,7 @@ import spikeextractors as se
 import spiketoolkit as st
 from labbox_ephys import prepare_snippets_h5
 
-@hi.function('createjob_fetch_average_waveform_plot_data', '')
+@hi.function('createjob_fetch_average_waveform_plot_data', '0.1.0')
 def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting_object, unit_id):
     jh = labbox.get_job_handler('partition2')
     jc = labbox.get_default_job_cache()
@@ -21,7 +21,7 @@ def createjob_fetch_average_waveform_plot_data(labbox, recording_object, sorting
             unit_id=unit_id
         )
 
-@hi.function('fetch_average_waveform_plot_data', '0.2.2')
+@hi.function('fetch_average_waveform_plot_data', '0.2.3')
 @hi.container('docker://magland/labbox-ephys-processing:0.2.18')
 @hi.local_modules(['../../../python/labbox_ephys'])
 def fetch_average_waveform_plot_data(snippets_h5, unit_id):
@@ -42,6 +42,7 @@ def fetch_average_waveform_plot_data(snippets_h5, unit_id):
 
     return dict(
         channel_id=int(maxchan_id),
+        sampling_frequency=sampling_frequency.item(),
         average_waveform=average_waveform[maxchan_index, :].astype(float).tolist()
     )
 


### PR DESCRIPTION
PR converts frame counts to milliseconds for the average spike waveform view. Spikes are now in the appropriate ~2ms range.

Within `AverageWaveform_ReactVis.js`, we had just been using the index of each frame entry as the x-coordinate for the plot. I converted these to msec by multiplying by 1000/sampling_frequency (where sampling frequency is in Hz).

Adjusted `fetch_average_waveform_plot_data` in `genplot_average_waveform.py` to pass along the sampling frequency as part of the plot data so that it would be available in `AverageWaveform_ReactVis.js`.