### PR TITLE
auto import py for extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
 		"ryanluker.vscode-coverage-gutters",
 		"zainchen.json",
 		"github.vscode-pull-request-github",
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"nsfilho.tosnippet"
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.vscode/labbox-snippets.code-snippets
+++ b/.vscode/labbox-snippets.code-snippets
@@ -1,0 +1,70 @@
+{
+	// Place your labbox-ephys workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"Print to console": {
+		"scope": "javascript,typescript",
+		"prefix": "debug",
+		"body": [
+			"console.log('---$1');",
+			"$2"
+		],
+		"description": "Debug log"
+	},
+	"extension": {
+		"prefix": "extension",
+		"body": [
+			"// LABBOX-EXTENSION: ${1: name}",
+			"",
+			"import React from 'react';",
+			"import { ExtensionContext } from \"../../extension\";",
+			"",
+			"// Use recordingview snippet to insert a recording view",
+			"",
+			"export function activate(context: ExtensionContext) {",
+			"    // Use registerrecordingview snippet to insert a recording view",
+			"    $0",
+			"}"
+		],
+		"description": ""
+	},
+	"recordingview": {
+        "prefix": "recordingview",
+        "body": [
+			"const ${1: ClassName}: FunctionComponent<RecordingViewProps> = ({recording}) => {",
+			"    $0",
+            "    return (",
+            "        <div>",
+            "            Example recording view. Recording ID: {recording.recordingId}",
+            "        </div>",
+            "    )",
+            "}"
+        ],
+        "description": ""
+	},
+	"registerrecordingview": {
+        "prefix": "registerrecordingview",
+        "body": [
+            "context.registerRecordingView({",
+            "    name: '${1: Name}',",
+            "    label: '${2: label}',",
+            "    priority: 50,",
+            "    component: ${3: ComponentName}",
+            "})"
+        ],
+        "description": ""
+    }
+}

--- a/python/api/api.py
+++ b/python/api/api.py
@@ -13,13 +13,16 @@ import websockets
 from labbox_ephys.api._session import Session
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(f'{thisdir}/../../src')
+sys.path.insert(0, f'{thisdir}/../../src')
 import pluginComponents
 
 pluginComponents # just keep the linter happy - we only need to import pluginComponents to register the hither functions
 import extensions
 
 extensions # just keep the linter happy - we only need to import extensions to register the hither functions
+
+# remove the prepended path so we don't have side-effects
+sys.path.remove(f'{thisdir}/../../src')
 
 print(f"LABBOX_EPHYS_DEPLOY: {os.environ.get('LABBOX_EPHYS_DEPLOY')}")
 

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,6 +1,6 @@
+import { Typography } from '@material-ui/core';
 import React from 'react';
 import './About.css';
-import { Typography } from '@material-ui/core';
 
 function Home() {
     return (

--- a/src/containers/RecordingView.js
+++ b/src/containers/RecordingView.js
@@ -52,7 +52,7 @@ const RecordingView = ({ recordingId, recording, sortings, history, documentInfo
         </Grid>
       </Grid>
       {
-          sortByPriority(recordingViews).map(rv => (
+          sortByPriority(recordingViews).filter(rv => (!rv.disabled)).map(rv => (
             <Expandable label={rv.label} defaultExpanded={rv.defaultExpanded ? true : false}>
               <rv.component
                 recording={recording}

--- a/src/containers/SortingView.tsx
+++ b/src/containers/SortingView.tsx
@@ -155,7 +155,7 @@ const SortingView: React.FunctionComponent<Props> = (props) => {
       }
       <div style={contentWrapperStyle}>
         {
-          sortByPriority(sortingViews).map(sv => {
+          sortByPriority(sortingViews).filter(v => (!v.disabled)).map(sv => {
             return (
               <Expandable
                 key={sv.name}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ interface ViewPlugin {
     props?: {[key: string]: any}
     fullWidth?: boolean
     defaultExpanded?: boolean
+    disabled?: boolean
 }
 
 export interface SortingViewProps {

--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -1,3 +1,18 @@
-from .averagewaveforms.genplot_average_waveform import \
-    fetch_average_waveform_plot_data
-from .correlograms.genplot_autocorrelogram import fetch_correlogram_plot_data
+# import hither functions by importing all subdirectories that have a __init__.py
+import importlib
+import os
+import sys
+
+# prepend this directory to the path so we can get the submodules, but remove it later to not cause side effects
+thisdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, f'{thisdir}')
+
+for a in os.listdir(thisdir):
+    dirpath = thisdir + '/' + a
+    if os.path.isdir(dirpath):
+        if os.path.isfile(dirpath + '/__init__.py'):
+            importlib.import_module(a)
+
+# remove so as not to cause side effects
+sys.path.remove(f'{thisdir}')
+        

--- a/src/extensions/averagewaveforms/__init__.py
+++ b/src/extensions/averagewaveforms/__init__.py
@@ -1,0 +1,2 @@
+# register hither functions
+from .genplot_average_waveform import *

--- a/src/extensions/correlograms/__init__.py
+++ b/src/extensions/correlograms/__init__.py
@@ -1,0 +1,2 @@
+# register hither functions
+from .genplot_autocorrelogram import *

--- a/src/extensions/example/example.tsx
+++ b/src/extensions/example/example.tsx
@@ -1,0 +1,24 @@
+// LABBOX-EXTENSION: example
+
+import React, { FunctionComponent } from 'react';
+import { ExtensionContext, RecordingViewProps } from "../../extension";
+
+// Use recordingview snippet to insert a recording view
+const ExampleRecordingView: FunctionComponent<RecordingViewProps> = ({recording}) => {
+    return (
+        <div>
+            Example recording view. Recording ID: {recording.recordingId}
+        </div>
+    )
+}
+
+export function activate(context: ExtensionContext) {
+    // Use registerrecordingview snippet to register a recording view
+    context.registerRecordingView({
+        name: 'ExampleRecordingView',
+        label: 'Example recording view',
+        priority: 50,
+        disabled: true,
+        component: ExampleRecordingView
+    })
+}

--- a/src/pluginComponents/IndividualUnits/IndividualUnit.tsx
+++ b/src/pluginComponents/IndividualUnits/IndividualUnit.tsx
@@ -119,7 +119,7 @@ const IndividualUnit: FunctionComponent<Props> = ({ sorting, recording, unitId, 
             <div>
                 <Grid container direction="row">
                     {
-                        sortByPriority(sortingUnitViews).map(suv => (
+                        sortByPriority(sortingUnitViews).filter(v => (!v.disabled)).map(suv => (
                             <Grid item key={suv.name}>
                                 <suv.component
                                     sorting={sorting}

--- a/src/registerExtensions.ts
+++ b/src/registerExtensions.ts
@@ -7,6 +7,8 @@ import { activate as activateIndividualUnits } from './pluginComponents/Individu
 import { activate as activateElectrodeGeometryTest2 } from './pluginComponents/ElectrodeGeometryTest2/ElectrodeGeometryTest2'
 import { activate as activateElectrodeGeometryTest } from './pluginComponents/ElectrodeGeometryTest/ElectrodeGeometryTest'
 import { activate as activatecorrelogram } from './extensions/correlograms/correlograms'
+import { activate as activateexample } from './extensions/example/example'
+import { activate as activatetest } from './extensions/test/test'
 import { activate as activateelectrodegeometry } from './extensions/electrodegeometry/electrodegeometry'
 import { activate as activatetimeseries } from './extensions/timeseries/timeseries'
 import { activate as activateaveragewaveforms } from './extensions/averagewaveforms/averagewaveforms'
@@ -27,6 +29,8 @@ const registerExtensions = (context: ExtensionContext) => {
     activateElectrodeGeometryTest2(context)
     activateElectrodeGeometryTest(context)
     activatecorrelogram(context)
+    activateexample(context)
+    activatetest(context)
     activateelectrodegeometry(context)
     activatetimeseries(context)
     activateaveragewaveforms(context)

--- a/src/registerExtensions.ts
+++ b/src/registerExtensions.ts
@@ -8,7 +8,6 @@ import { activate as activateElectrodeGeometryTest2 } from './pluginComponents/E
 import { activate as activateElectrodeGeometryTest } from './pluginComponents/ElectrodeGeometryTest/ElectrodeGeometryTest'
 import { activate as activatecorrelogram } from './extensions/correlograms/correlograms'
 import { activate as activateexample } from './extensions/example/example'
-import { activate as activatetest } from './extensions/test/test'
 import { activate as activateelectrodegeometry } from './extensions/electrodegeometry/electrodegeometry'
 import { activate as activatetimeseries } from './extensions/timeseries/timeseries'
 import { activate as activateaveragewaveforms } from './extensions/averagewaveforms/averagewaveforms'
@@ -30,7 +29,6 @@ const registerExtensions = (context: ExtensionContext) => {
     activateElectrodeGeometryTest(context)
     activatecorrelogram(context)
     activateexample(context)
-    activatetest(context)
     activateelectrodegeometry(context)
     activatetimeseries(context)
     activateaveragewaveforms(context)


### PR DESCRIPTION
importing of hither functions in extensions is now handled as follows:

To register a hither function:
* Include hither function in a .py file in extension directory
* Include __init__.py in the extension directory and import the hither function

Now the hither function will automatically be registered. This is handled by the following file:

https://github.com/laboratorybox/labbox-ephys/blob/auto-import-py/src/extensions/__init__.py