### PR TITLE
support external sorting unit metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/react-redux": "^7.1.11",
+    "@types/react-router": "^5.1.8",
     "@types/react-router-dom": "^5.1.6",
     "axios": "^0.19.2",
     "github-markdown-css": "^4.0.0",

--- a/python/labbox_ephys/misc/get_sorting_info.py
+++ b/python/labbox_ephys/misc/get_sorting_info.py
@@ -1,6 +1,8 @@
 import hither as hi
-import numpy as np
+import kachery_p2p as kp
 import labbox_ephys as le
+import numpy as np
+
 
 @hi.function('createjob_get_sorting_info', '0.1.0')
 def createjob_get_sorting_info(labbox, sorting_object, recording_object):
@@ -18,6 +20,14 @@ def get_sorting_info(sorting_object, recording_object):
         unit_ids=_to_int_list(sorting.get_unit_ids()),
         samplerate=recording.get_sampling_frequency()
     )
+
+@hi.function('fetch_external_sorting_unit_metrics', '0.1.0')
+def fetch_external_sorting_unit_metrics(labbox, uri):
+    return load_object.run(uri=uri)
+
+@hi.function('load_object', '0.1.0')
+def load_object(uri):
+    return kp.load_object(uri)
 
 def _to_int_list(x):
     return np.array(x).astype(int).tolist()

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -5,7 +5,7 @@ import { DatabaseConfig, SetDatabaseConfigAction } from '../reducers/databaseCon
 import { DocumentInfo, SetDocumentInfoAction } from '../reducers/documentInfo'
 import { SetPersistStatusAction } from '../reducers/persisting'
 import { AddRecordingAction, Recording, RecordingInfo, SetRecordingInfoAction } from '../reducers/recordings'
-import { AddSortingAction, AddUnitLabelAction, DeleteSortingsAction, RemoveUnitLabelAction, SetSortingInfoAction, Sorting, SortingInfo } from '../reducers/sortings'
+import { AddSortingAction, AddUnitLabelAction, DeleteSortingsAction, ExternalSortingUnitMetric, RemoveUnitLabelAction, SetExternalSortingUnitMetricsAction, SetSortingInfoAction, Sorting, SortingInfo } from '../reducers/sortings'
 
 export const REPORT_INITIAL_LOAD_COMPLETE = 'REPORT_INITIAL_LOAD_COMPLETE'
 export const SET_WEBSOCKET_STATUS = 'SET_WEBSOCKET_STATUS'
@@ -23,6 +23,7 @@ export const ADD_SORTING = 'ADD_SORTING'
 export const DELETE_SORTINGS = 'DELETE_SORTINGS'
 export const DELETE_ALL_SORTINGS_FOR_RECORDINGS = 'DELETE_ALL_SORTINGS_FOR_RECORDINGS'
 export const SET_SORTING_INFO = 'SET_SORTING_INFO'
+export const SET_EXTERNAL_SORTING_UNIT_METRICS = 'SET_EXTERNAL_SORTING_UNIT_METRICS'
 
 export const INIT_FETCH_SORTING_INFO = 'INIT_FETCH_SORTING_INFO'
 export const RECEIVE_SORTING_INFO = 'RECEIVE_SORTING_INFO'
@@ -56,6 +57,12 @@ export const setSortingInfo = (a: { sortingId: string, sortingInfo: SortingInfo 
     type: SET_SORTING_INFO,
     sortingId: a.sortingId,
     sortingInfo: a.sortingInfo
+})
+
+export const setExternalSortingUnitMetrics = (a: { sortingId: string, externalUnitMetrics: ExternalSortingUnitMetric[] }): SetExternalSortingUnitMetricsAction => ({
+  type: SET_EXTERNAL_SORTING_UNIT_METRICS,
+  sortingId: a.sortingId,
+  externalUnitMetrics: a.externalUnitMetrics
 })
 
 interface PersistAction {

--- a/src/containers/SortingView.tsx
+++ b/src/containers/SortingView.tsx
@@ -4,7 +4,7 @@ import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { addUnitLabel, removeUnitLabel, setSortingInfo } from '../actions';
 import SortingInfoView from '../components/SortingInfoView';
-import { SortingUnitViewPlugin, SortingViewPlugin } from '../extension';
+import { SortingUnitMetricPlugin, SortingUnitViewPlugin, SortingViewPlugin } from '../extension';
 import { createHitherJob } from '../hither';
 import { getPathQuery } from '../kachery';
 import { RootAction, RootState } from '../reducers';
@@ -26,6 +26,7 @@ const intrange = (a: number, b: number) => {
 interface StateProps {
   sortingViews: {[key: string]: SortingViewPlugin}
   sortingUnitViews: {[key: string]: SortingUnitViewPlugin}
+  sortingUnitMetrics: {[key: string]: SortingUnitMetricPlugin}
   sorting: Sorting | undefined
   recording: Recording | undefined
   extensionsConfig: any
@@ -49,7 +50,7 @@ type SortingInfoStatus = 'waiting' | 'computing' | 'finished'
 type SelectedUnitIds = {[key: string]: boolean}
 
 const SortingView: React.FunctionComponent<Props> = (props) => {
-  const { sortingViews, sortingUnitViews, documentInfo, sorting, sortingId, recording, onSetSortingInfo, onAddUnitLabel, onRemoveUnitLabel, extensionsConfig } = props
+  const { sortingViews, sortingUnitViews, documentInfo, sorting, sortingId, recording, onSetSortingInfo, onAddUnitLabel, onRemoveUnitLabel, extensionsConfig, sortingUnitMetrics } = props
   const { documentId, feedUri, readOnly } = documentInfo;
   const [sortingInfoStatus, setSortingInfoStatus] = useState<SortingInfoStatus>('waiting');
   // const [selection, dispatchSelection] = useReducer(updateSelections, {focusedUnitId: null, selectedUnitIds: {}});
@@ -177,6 +178,7 @@ const SortingView: React.FunctionComponent<Props> = (props) => {
                   }}
                   readOnly={readOnly}
                   sortingUnitViews={sortingUnitViews}
+                  sortingUnitMetrics={sortingUnitMetrics}
                 />
               </Expandable>
             )
@@ -213,6 +215,7 @@ function findRecordingForId(state: any, id: string): Recording | undefined {
 const mapStateToProps: MapStateToProps<StateProps, OwnProps, RootState> = (state: RootState, ownProps: OwnProps): StateProps => ({ // todo
   sortingViews: state.extensionContext.sortingViews,
   sortingUnitViews: state.extensionContext.sortingUnitViews,
+  sortingUnitMetrics: state.extensionContext.sortingUnitMetrics,
   // todo: use selector
   sorting: findSortingForId(state, ownProps.sortingId),
   recording: findRecordingForId(state, (findSortingForId(state, ownProps.sortingId) || {recordingId: ''}).recordingId),

--- a/src/containers/SortingView.tsx
+++ b/src/containers/SortingView.tsx
@@ -2,7 +2,7 @@ import { Accordion, AccordionDetails, AccordionSummary, CircularProgress } from 
 import React, { Dispatch, useCallback, useEffect, useState } from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
-import { addUnitLabel, removeUnitLabel, setSortingInfo } from '../actions';
+import { addUnitLabel, removeUnitLabel, setExternalSortingUnitMetrics, setSortingInfo } from '../actions';
 import SortingInfoView from '../components/SortingInfoView';
 import { SortingUnitMetricPlugin, SortingUnitViewPlugin, SortingViewPlugin } from '../extension';
 import { createHitherJob } from '../hither';
@@ -11,7 +11,7 @@ import { RootAction, RootState } from '../reducers';
 import { DocumentInfo } from '../reducers/documentInfo';
 import { sortByPriority } from '../reducers/extensionContext';
 import { Recording } from '../reducers/recordings';
-import { Sorting, SortingInfo } from '../reducers/sortings';
+import { ExternalSortingUnitMetric, Sorting, SortingInfo } from '../reducers/sortings';
 
 const intrange = (a: number, b: number) => {
   const lower = a < b ? a : b;
@@ -35,6 +35,7 @@ interface StateProps {
 
 interface DispatchProps {
   onSetSortingInfo: (a: {sortingId: string, sortingInfo: SortingInfo}) => void
+  onSetExternalUnitMetrics: (a: { sortingId: string, externalUnitMetrics: ExternalSortingUnitMetric[] }) => void
   onAddUnitLabel: (a: { sortingId: string, unitId: number, label: string }) => void
   onRemoveUnitLabel: (a: { sortingId: string, unitId: number, label: string }) => void
 }
@@ -45,31 +46,60 @@ interface OwnProps {
 
 type Props = StateProps & DispatchProps & OwnProps & RouteComponentProps
 
-type SortingInfoStatus = 'waiting' | 'computing' | 'finished'
+type CalcStatus = 'waiting' | 'computing' | 'finished'
 
 type SelectedUnitIds = {[key: string]: boolean}
 
 const SortingView: React.FunctionComponent<Props> = (props) => {
-  const { sortingViews, sortingUnitViews, documentInfo, sorting, sortingId, recording, onSetSortingInfo, onAddUnitLabel, onRemoveUnitLabel, extensionsConfig, sortingUnitMetrics } = props
+  const { sortingViews, sortingUnitViews, documentInfo, sorting, sortingId, recording, onSetSortingInfo, onSetExternalUnitMetrics, onAddUnitLabel, onRemoveUnitLabel, extensionsConfig, sortingUnitMetrics } = props
   const { documentId, feedUri, readOnly } = documentInfo;
-  const [sortingInfoStatus, setSortingInfoStatus] = useState<SortingInfoStatus>('waiting');
+  const [sortingInfoStatus, setSortingInfoStatus] = useState<CalcStatus>('waiting');
+  const [externalUnitMetricsStatus, setExternalUnitMetricsStatus] = useState<CalcStatus>('waiting');
   // const [selection, dispatchSelection] = useReducer(updateSelections, {focusedUnitId: null, selectedUnitIds: {}});
   const [selectedUnitIds, setSelectedUnitIds] = useState<SelectedUnitIds>({})
   const [focusedUnitId, setFocusedUnitId] = useState<number | null>(null)
 
-  const effect = async () => {
+  // const effect = async () => {
+  //   if ((sorting) && (recording) && (!sorting.sortingInfo) && (sortingInfoStatus === 'waiting')) {
+  //     setSortingInfoStatus('computing');
+  //     const sortingInfo = await createHitherJob(
+  //       'createjob_get_sorting_info',
+  //       { sorting_object: sorting.sortingObject, recording_object: recording.recordingObject },
+  //       { kachery_config: {}, useClientCache: true, wait: true, newHitherJobMethod: true}
+  //     );
+  //     onSetSortingInfo({ sortingId, sortingInfo });
+  //     setSortingInfoStatus('finished');
+  //   }
+  // }
+  // useEffect(() => {effect()});
+
+  useEffect(() => {
     if ((sorting) && (recording) && (!sorting.sortingInfo) && (sortingInfoStatus === 'waiting')) {
       setSortingInfoStatus('computing');
-      const sortingInfo = await createHitherJob(
+      createHitherJob(
         'createjob_get_sorting_info',
         { sorting_object: sorting.sortingObject, recording_object: recording.recordingObject },
         { kachery_config: {}, useClientCache: true, wait: true, newHitherJobMethod: true}
-      );
-      onSetSortingInfo({ sortingId, sortingInfo });
-      setSortingInfoStatus('finished');
+      ).then((sortingInfo: SortingInfo) => {
+        onSetSortingInfo({ sortingId, sortingInfo });
+        setSortingInfoStatus('finished');
+      })
     }
-  }
-  useEffect(() => {effect()});
+  }, [onSetSortingInfo, setSortingInfoStatus, sortingInfoStatus, recording, sorting, sortingId])
+
+  useEffect(() => {
+    if ((sorting) && (sorting.externalUnitMetricsUri) && (!sorting.externalUnitMetrics) && (externalUnitMetricsStatus === 'waiting')) {
+      setExternalUnitMetricsStatus('computing');
+      createHitherJob(
+        'fetch_external_sorting_unit_metrics',
+        { uri: sorting.externalUnitMetricsUri },
+        { kachery_config: {}, useClientCache: true, wait: true, newHitherJobMethod: true}
+      ).then((externalUnitMetrics: ExternalSortingUnitMetric[]) => {
+        onSetExternalUnitMetrics({ sortingId, externalUnitMetrics });
+        setExternalUnitMetricsStatus('finished');
+      })
+    }
+  }, [onSetExternalUnitMetrics, setExternalUnitMetricsStatus, externalUnitMetricsStatus, sorting, sortingId])
 
   const handleUnitClicked = useCallback((unitId, event) => {
     if (event.ctrlKey) {
@@ -145,7 +175,8 @@ const SortingView: React.FunctionComponent<Props> = (props) => {
         (sortingInfoStatus === 'computing') ? (
           <div><CircularProgress /></div>
         ) : (
-          <SortingInfoView sortingInfo={sorting.sortingInfo}
+          <SortingInfoView
+            sortingInfo={sorting.sortingInfo}
             selections={selectedUnitIds}
             focus={focusedUnitId !== null ? focusedUnitId : undefined}
             onUnitClicked={handleUnitClicked}
@@ -225,6 +256,7 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RootState> = (state
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = (dispatch: Dispatch<RootAction>, ownProps: OwnProps) => ({
   onSetSortingInfo: (a: { sortingId: string, sortingInfo: SortingInfo }) => dispatch(setSortingInfo(a)),
+  onSetExternalUnitMetrics: (a: { sortingId: string, externalUnitMetrics: ExternalSortingUnitMetric[] }) => dispatch(setExternalSortingUnitMetrics(a)),
   onAddUnitLabel: (a: { sortingId: string, unitId: number, label: string }) => dispatch(addUnitLabel(a)),
   onRemoveUnitLabel: (a: { sortingId: string, unitId: number, label: string }) => dispatch(removeUnitLabel(a)),
 })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,20 +1,27 @@
 import { Dispatch } from "react"
-import { ExtensionsConfig } from './extensions/reducers'
 import CalculationPool from "./extensions/common/CalculationPool"
+import { ExtensionsConfig } from './extensions/reducers'
 import { RootAction } from "./reducers"
 import { DocumentInfo } from './reducers/documentInfo'
-import { RegisterRecordingViewAction, RegisterSortingUnitViewAction, RegisterSortingViewAction } from './reducers/extensionContext'
+import { RegisterRecordingViewAction, RegisterSortingUnitMetricAction, RegisterSortingUnitViewAction, RegisterSortingViewAction } from './reducers/extensionContext'
 import { Recording } from "./reducers/recordings"
 import { Sorting } from "./reducers/sortings"
 
-interface ViewPlugin {
+interface Plugin {
     name: string
     label: string
     priority?: number
+    disabled?: boolean
+}
+
+interface ViewPlugin extends Plugin {
     props?: {[key: string]: any}
     fullWidth?: boolean
     defaultExpanded?: boolean
-    disabled?: boolean
+}
+
+interface MetricPlugin extends Plugin {
+    
 }
 
 export interface SortingViewProps {
@@ -38,6 +45,7 @@ export interface SortingViewProps {
     onSelectedUnitIdsChanged: (selectedUnitIds: {[key: string]: boolean}) => void
     readOnly: boolean | null
     sortingUnitViews: {[key: string]: SortingUnitViewPlugin} // maybe this doesn't belong here
+    sortingUnitMetrics: {[key: string]: SortingUnitMetricPlugin}
 }
 
 export interface SortingViewPlugin extends ViewPlugin {
@@ -63,6 +71,24 @@ export interface RecordingViewProps {
 
 export interface RecordingViewPlugin extends ViewPlugin {
     component: React.ComponentType<RecordingViewProps>
+}
+
+export interface SortingUnitMetricPlugin extends MetricPlugin {
+    columnLabel: string,
+    tooltip: string,
+    hitherFnName: string,
+    metricFnParams: {[key: string]: any},
+    hitherConfig: {
+        auto_substitute_file_objects?: boolean,
+        hither_config?: {
+            use_job_cache: boolean
+        },
+        job_handler_name?: string
+        wait?: boolean,
+        useClientCache?: boolean,
+        newHitherJobMethod?: boolean
+    },
+    component: React.FunctionComponent<{record: any}>
 }
 
 export class ExtensionContext {
@@ -96,6 +122,16 @@ export class ExtensionContext {
         this.dispatch(a)
     }
     unregisterRecordingView(name: string) {
+        // todo
+    }
+    registerSortingUnitMetric(M: SortingUnitMetricPlugin) {
+        const a: RegisterSortingUnitMetricAction = {
+            type: 'REGISTER_SORTING_UNIT_METRIC',
+            sortingUnitMetric: M
+        }
+        this.dispatch(a)
+    }
+    unregisterSortingUnitMetric(name: string) {
         // todo
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,11 @@ export interface SortingUnitMetricPlugin extends MetricPlugin {
         newHitherJobMethod?: boolean
     },
     component: React.FunctionComponent<{record: any}>
+    getRecordValue: (record: any) => { 
+        numericValue: number, 
+        stringValue: string,
+        isNumeric: boolean
+    }
 }
 
 export class ExtensionContext {

--- a/src/extensions/devel/IndividualUnits/IndividualUnits.tsx
+++ b/src/extensions/devel/IndividualUnits/IndividualUnits.tsx
@@ -13,10 +13,12 @@ const IndividualUnits: FunctionComponent<SortingViewProps & {size: {width: numbe
     const maxUnitsVisibleIncrement = 4;
     const [maxUnitsVisible, setMaxUnitsVisible] = useState(4);
     const { documentId, feedUri, readOnly } = documentInfo || {};
+    const { sortingInfo } = sorting
+    if (!sortingInfo) return <div>No sorting info</div>
 
     let selectedUnitIdsArray =
         Object.keys(selectedUnitIds).filter(k => selectedUnitIds[k])
-        .filter(id => sorting.sortingInfo.unit_ids.includes(parseInt(id)))
+        .filter(id => sortingInfo.unit_ids.includes(parseInt(id)))
         .map(id => parseInt(id));
     
     let showExpandButton = false;
@@ -50,7 +52,7 @@ const IndividualUnits: FunctionComponent<SortingViewProps & {size: {width: numbe
                             unitId={id}
                             calculationPool={individualUnitsCalculationPool}
                             width={size.width}
-                            sortingInfo={sorting.sortingInfo}
+                            sortingInfo={sortingInfo}
                             sortingUnitViews={sortingUnitViews}
                         />
                         <Link to={`/${documentId}/sortingUnit/${sorting.sortingId}/${id}/${getPathQuery({feedUri})}`}>

--- a/src/extensions/unitstable/Units/Units.tsx
+++ b/src/extensions/unitstable/Units/Units.tsx
@@ -66,7 +66,7 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
             Object.keys(sorting.unitCuration || {})
                 .reduce(
                     (allLabels: Label[], unitId: string) => {
-                        const u = (sorting.unitCuration)[unitId]
+                        const u = (sorting.unitCuration || {})[unitId]
                         return allLabels.concat(u.labels || [])
                     }, [])
         )
@@ -114,8 +114,10 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
         sortByPriority(sortingUnitMetrics).filter(p => (!p.disabled)).forEach(async mp => await fetchMetric(mp));
     }, [sortingUnitMetrics, metrics, fetchMetric]);
 
+    const { sortingInfo } = sorting
+    if (!sortingInfo) return <div>No sorting info</div>
 
-    const selectedRowKeys = sorting.sortingInfo.unit_ids
+    const selectedRowKeys = sortingInfo.unit_ids
         .reduce((obj, id) => ({...obj, [id]: selectedUnitIds[id] || false}), {});
 
     const handleAddLabel = (unitId: number, label: Label) => {
@@ -135,7 +137,7 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
             : {});
     };
 
-    let units = sorting.sortingInfo.unit_ids;
+    let units = sortingInfo.unit_ids;
     let showExpandButton = false;
     if ((!expandedTable) && (units.length > 30)) {
         units = units.slice(0, 30);

--- a/src/extensions/unitstable/Units/Units.tsx
+++ b/src/extensions/unitstable/Units/Units.tsx
@@ -2,22 +2,21 @@
 import { Button, CircularProgress, Paper } from '@material-ui/core';
 import React, { useCallback, useEffect, useReducer, useState } from 'react';
 import MultiComboBox from '../../../components/MultiComboBox';
-import { SortingViewProps } from '../../../extension';
+import { SortingUnitMetricPlugin, SortingViewProps } from '../../../extension';
 import { createHitherJob } from '../../../hither';
-import * as pluginComponents from './metricPlugins';
-import { MetricPlugin } from './metricPlugins/common';
+import { sortByPriority } from '../../../reducers/extensionContext';
 import UnitsTable from './UnitsTable';
 
 const defaultLabelOptions = ['noise', 'MUA', 'artifact', 'accept', 'reject'];
 
-const metricPlugins: MetricPlugin[] = Object.values(pluginComponents)
-                            .filter(plugin => {
-                                const p = plugin as any
-                                return (p.type === 'metricPlugin')
-                            })
-                            .map(plugin => {
-                                return plugin as MetricPlugin
-                            })
+// const metricPlugins: MetricPlugin[] = Object.values(pluginComponents)
+//                             .filter(plugin => {
+//                                 const p = plugin as any
+//                                 return (p.type === 'metricPlugin')
+//                             })
+//                             .map(plugin => {
+//                                 return plugin as MetricPlugin
+//                             })
 
 type Status = 'waiting' | 'completed' | 'executing' | 'error'
 
@@ -55,12 +54,12 @@ const updateMetricData = (state: MetricDataState, action: MetricDataAction): Met
 type Label = string
 
 const Units: React.FunctionComponent<SortingViewProps> = (props) => {
-    const { extensionsConfig, sorting, recording, selectedUnitIds, onAddUnitLabel, onRemoveUnitLabel, onSelectedUnitIdsChanged, readOnly, documentInfo } = props
+    const { extensionsConfig, sorting, recording, selectedUnitIds, onAddUnitLabel, onRemoveUnitLabel, onSelectedUnitIdsChanged, readOnly, documentInfo, sortingUnitMetrics } = props
     const [activeOptions, setActiveOptions] = useState([]);
     const [expandedTable, setExpandedTable] = useState(false);
     const [metrics, updateMetrics] = useReducer(updateMetricData, initialMetricDataState);
-    const activeMetricPlugins = metricPlugins.filter(
-        p => (!p.development || (extensionsConfig.enabled.development)));
+    // const activeMetricPlugins = metricPlugins.filter(
+    //     p => (!p.development || (extensionsConfig.enabled.development)));
 
     const labelOptions = [...new Set(
         defaultLabelOptions.concat(
@@ -83,9 +82,8 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
         return 0;
     });
 
-    const fetchMetric = useCallback(async (metric = {metricName: '', hitherFnName: '',
-                                                    metricFnParams: {}, hitherConfig: {}}) => {
-        const name = metric.metricName;
+    const fetchMetric = useCallback(async (metric: SortingUnitMetricPlugin) => {
+        const name = metric.name;
 
         if (name in metrics) {
             return metrics[name];
@@ -93,7 +91,7 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
         // TODO: FIXME! THIS STATE IS NOT PRESERVED BETWEEN UNFOLDINGS!!!
         // TODO: May need to bump this up to the parent!!!
         // new request. Add state to cache, dispatch job, then update state as results come back.
-        updateMetrics({metricName: metric.metricName, status: 'executing'})
+        updateMetrics({metricName: metric.name, status: 'executing'})
         try {
             const data = await createHitherJob(metric.hitherFnName,
                 {
@@ -105,16 +103,16 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
                     ...metric.hitherConfig,
                     required_files: sorting.sortingObject
                 });
-            updateMetrics({metricName: metric.metricName, status: 'completed', data})
+            updateMetrics({metricName: metric.name, status: 'completed', data})
         } catch (err) {
             console.error(err);
-            updateMetrics({metricName: metric.metricName, status: 'error', error: err.message})
+            updateMetrics({metricName: metric.name, status: 'error', error: err.message})
         }
     }, [metrics, sorting.sortingObject, recording.recordingObject]);
 
     useEffect(() => { 
-        activeMetricPlugins.forEach(async mp => await fetchMetric(mp));
-    }, [activeMetricPlugins, metrics, fetchMetric]);
+        sortByPriority(sortingUnitMetrics).filter(p => (!p.disabled)).forEach(async mp => await fetchMetric(mp));
+    }, [sortingUnitMetrics, metrics, fetchMetric]);
 
 
     const selectedRowKeys = sorting.sortingInfo.unit_ids
@@ -156,7 +154,7 @@ const Units: React.FunctionComponent<SortingViewProps> = (props) => {
         <div style={{'width': '100%'}}>
             <Paper style={{maxHeight: 350, overflow: 'auto'}}>
                 <UnitsTable 
-                    metricPlugins={activeMetricPlugins}
+                    sortingUnitMetrics={sortingUnitMetrics}
                     units={units}
                     metrics={metrics}
                     selectedUnitIds={selectedUnitIds}

--- a/src/extensions/unitstable/Units/UnitsTable.tsx
+++ b/src/extensions/unitstable/Units/UnitsTable.tsx
@@ -123,17 +123,13 @@ const UnitsTable: FunctionComponent<Props> = (props) => {
     for (const r of sortingRules) {
         const metricName = r.metricName
         const metric = metrics[metricName]
-        console.log(`Now sorting by ${metricName}`)
         if (!metric || !metric.data || metric['error']) continue // no data, nothing to do
-//        const comparer = metricPlugins.filter(mp => mp.metricName === metricName)[0].comparer(metric.data)
-//        if (!comparer) continue // should not happen
         const getRecordForMetric = sortingUnitMetricsList.filter(mp => mp.name === metricName)[0].getRecordValue
         units.sort((a, b) => {
             const recordA = getRecordForMetric(metric.data[a + ''])
             const recordB = getRecordForMetric(metric.data[b + ''])
             return sortMetricValues(recordA, recordB, r.sortAscending)
         })
-        console.log(`Units now sorted to ${JSON.stringify(units)}`)
     }
     return (
         <Table className="NiceTable">

--- a/src/extensions/unitstable/Units/UnitsTable.tsx
+++ b/src/extensions/unitstable/Units/UnitsTable.tsx
@@ -12,7 +12,7 @@ const getLabelsForUnitId = (unitId: number, sorting: Sorting) => {
     return (unitCuration[unitId] || {}).labels || [];
 }
 
-const HeaderRow = React.memo((a: {sortingUnitMetrics: {[key: string]: SortingUnitMetricPlugin}}) => {
+const HeaderRow = React.memo((a: {columnLabels: string[]}) => {
     return (
         <TableHead>
             <TableRow>
@@ -20,10 +20,10 @@ const HeaderRow = React.memo((a: {sortingUnitMetrics: {[key: string]: SortingUni
                 <TableCell key="_unitIds"><span>Unit ID</span></TableCell>
                 <TableCell key="_labels"><span>Labels</span></TableCell>
                 {
-                    sortByPriority(Object.values(a.sortingUnitMetrics)).filter(p => (!p.disabled)).map(plugin => {
+                    a.columnLabels.map(columnLabel => {
                         return (
-                            <TableCell key={plugin.columnLabel + '_header'}>
-                                <span title={plugin.tooltip}>{plugin.columnLabel}</span>
+                            <TableCell key={columnLabel + '_header'}>
+                                <span title={columnLabel} />
                             </TableCell>
                         );
                     })
@@ -95,10 +95,11 @@ const toggleSelectedUnitId = (selectedUnitIds: {[key: string]: boolean}, unitId:
 
 const UnitsTable: FunctionComponent<Props> = (props) => {
     const { units, metrics, selectedUnitIds, sorting, onSelectedUnitIdsChanged, documentInfo, sortingUnitMetrics } = props
+    const sortingUnitMetricsList = sortByPriority(Object.values(sortingUnitMetrics)).filter(p => (!p.disabled))
     return (
         <Table className="NiceTable">
             <HeaderRow 
-                sortingUnitMetrics={sortingUnitMetrics}
+                columnLabels={sortingUnitMetricsList.map(m => (m.columnLabel))}
             />
             <TableBody>
                 {
@@ -119,7 +120,7 @@ const UnitsTable: FunctionComponent<Props> = (props) => {
                                 labels = {getLabelsForUnitId(unitId, sorting).join(', ')}
                             />
                             {
-                                sortByPriority(Object.values(sortingUnitMetrics)).filter(p => (!p.disabled)).map(mp => {
+                                sortingUnitMetricsList.map(mp => {
                                     const metricName = mp.name
                                     const metric = metrics[metricName] || null
                                     const d = (metric && metric.data) ? (

--- a/src/extensions/unitstable/Units/metricPlugins/EventCount.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/EventCount.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { MetricPlugin } from './common';
+import React, { FunctionComponent } from 'react';
+import { SortingUnitMetricPlugin } from '../../../../extension';
 
-const EventCount = React.memo((a: {record: {count: number}}) => {
+const EventCount: FunctionComponent<{record: any}> = ({record}) => {
     return (
-        <span>{a.record.count}</span>
+        <span>{record.count}</span>
     );
-});
+}
 
-const plugin: MetricPlugin = {
-    type: 'metricPlugin',
-    metricName: 'EventCount',
+const plugin: SortingUnitMetricPlugin = {
+    name: 'EventCount',
+    label: 'Num. events',
     columnLabel: 'Num. events',
     tooltip: 'Number of firing events',
     hitherFnName: 'createjob_get_firing_data',
@@ -19,8 +19,7 @@ const plugin: MetricPlugin = {
         useClientCache: true,
         newHitherJobMethod: true
     },
-    component: EventCount,
-    development: false
+    component: EventCount
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/EventCount.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/EventCount.tsx
@@ -7,6 +7,14 @@ const EventCount: FunctionComponent<{record: any}> = ({record}) => {
     );
 }
 
+const getRecordValue = (record: any) => {
+    return { 
+        numericValue: Number(record?.count ?? NaN), 
+        stringValue: '',
+        isNumeric: true
+    }
+}
+
 const plugin: SortingUnitMetricPlugin = {
     name: 'EventCount',
     label: 'Num. events',
@@ -19,7 +27,8 @@ const plugin: SortingUnitMetricPlugin = {
         useClientCache: true,
         newHitherJobMethod: true
     },
-    component: EventCount
+    component: EventCount,
+    getRecordValue: getRecordValue,
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/FiringRate.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/FiringRate.tsx
@@ -7,6 +7,14 @@ const FiringRate = React.memo((a: {record: {rate: number}}) => {
     );
 })
 
+const getRecordValue = (record: any) => {
+    return { 
+        numericValue: record?.rate ?? NaN, 
+        stringValue: '',
+        isNumeric: true
+    }
+}
+
 const plugin: SortingUnitMetricPlugin = {
     name: 'FiringRate',
     label: 'Firing rate (Hz)',
@@ -23,7 +31,8 @@ const plugin: SortingUnitMetricPlugin = {
         },
         job_handler_name: 'partition3'
     },
-    component: FiringRate
+    component: FiringRate,
+    getRecordValue: getRecordValue
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/FiringRate.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/FiringRate.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MetricPlugin } from './common';
+import { SortingUnitMetricPlugin } from '../../../../extension';
 
 const FiringRate = React.memo((a: {record: {rate: number}}) => {
     return (
@@ -7,9 +7,9 @@ const FiringRate = React.memo((a: {record: {rate: number}}) => {
     );
 })
 
-const plugin: MetricPlugin = {
-    type: 'metricPlugin',
-    metricName: 'FiringRate',
+const plugin: SortingUnitMetricPlugin = {
+    name: 'FiringRate',
+    label: 'Firing rate (Hz)',
     columnLabel: 'Firing rate (Hz)',
     tooltip: 'Average events per second',
     hitherFnName: 'get_firing_data',
@@ -23,8 +23,7 @@ const plugin: MetricPlugin = {
         },
         job_handler_name: 'partition3'
     },
-    component: FiringRate,
-    development: false
+    component: FiringRate
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/IsiViolations.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/IsiViolations.tsx
@@ -7,6 +7,14 @@ const IsiViolations = React.memo((a: {record: number}) => {
     );
 })
 
+const getRecordValue = (record: any) => {
+    return { 
+        numericValue: record ? record as number : NaN, 
+        stringValue: '',
+        isNumeric: true
+    }
+}
+
 const plugin: SortingUnitMetricPlugin = {
     name: 'IsiViolations',
     label: 'ISI viol.',
@@ -23,7 +31,8 @@ const plugin: SortingUnitMetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: IsiViolations
+    component: IsiViolations,
+    getRecordValue: getRecordValue
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/IsiViolations.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/IsiViolations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MetricPlugin } from './common';
+import { SortingUnitMetricPlugin } from '../../../../extension';
 
 const IsiViolations = React.memo((a: {record: number}) => {
     return (
@@ -7,9 +7,9 @@ const IsiViolations = React.memo((a: {record: number}) => {
     );
 })
 
-const plugin: MetricPlugin = {
-    type: 'metricPlugin',
-    metricName: 'IsiViolations',
+const plugin: SortingUnitMetricPlugin = {
+    name: 'IsiViolations',
+    label: 'ISI viol.',
     columnLabel: 'ISI viol.',
     tooltip: 'ISI violation rate',
     hitherFnName: 'createjob_get_isi_violation_rates',
@@ -23,8 +23,7 @@ const plugin: MetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: IsiViolations,
-    development: false
+    component: IsiViolations
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/PeakChannels.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/PeakChannels.tsx
@@ -7,6 +7,14 @@ const PeakChannels = React.memo((a: {record: number}) => {
     );
 })
 
+const getRecordValue = (record: any) => {
+    return { 
+        numericValue: ((record) || (record === 0)) ? record as number : NaN, 
+        stringValue: '',
+        isNumeric: true
+    }
+}
+
 const plugin: SortingUnitMetricPlugin = {
     name: 'PeakChannels',
     label: 'Peak chan.',
@@ -19,7 +27,8 @@ const plugin: SortingUnitMetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: PeakChannels
+    component: PeakChannels,
+    getRecordValue: getRecordValue
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/PeakChannels.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/PeakChannels.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MetricPlugin } from './common';
+import { SortingUnitMetricPlugin } from '../../../../extension';
 
 const PeakChannels = React.memo((a: {record: number}) => {
     return (
@@ -7,9 +7,9 @@ const PeakChannels = React.memo((a: {record: number}) => {
     );
 })
 
-const plugin: MetricPlugin = {
-    type: 'metricPlugin',
-    metricName: 'PeakChannels',
+const plugin: SortingUnitMetricPlugin = {
+    name: 'PeakChannels',
+    label: 'Peak chan.',
     columnLabel: 'Peak chan.',
     tooltip: 'ID of channel where the peak-to-peak amplitude is maximal',
     hitherFnName: 'createjob_get_peak_channels',
@@ -19,8 +19,7 @@ const plugin: MetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: PeakChannels,
-    development: false
+    component: PeakChannels
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/UnitSnrs.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/UnitSnrs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MetricPlugin } from './common';
+import { SortingUnitMetricPlugin } from '../../../../extension';
 
 const UnitSnrs = React.memo((a: {record: number}) => {
     return (
@@ -7,9 +7,9 @@ const UnitSnrs = React.memo((a: {record: number}) => {
     );
 })
 
-const plugin: MetricPlugin = {
-    type: 'metricPlugin',
-    metricName: 'UnitSnrs',
+const plugin: SortingUnitMetricPlugin = {
+    name: 'UnitSnrs',
+    label: 'SNR',
     columnLabel: 'SNR',
     tooltip: 'Unit SNR (peak-to-peak amp of mean waveform / est. std. dev on peak chan)',
     hitherFnName: 'createjob_get_unit_snrs',
@@ -19,8 +19,7 @@ const plugin: MetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: UnitSnrs,
-    development: false
+    component: UnitSnrs
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/UnitSnrs.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/UnitSnrs.tsx
@@ -7,6 +7,14 @@ const UnitSnrs = React.memo((a: {record: number}) => {
     );
 })
 
+const getRecordValue = (record: any) => {
+    return { 
+        numericValue: record ? record as number : NaN, 
+        stringValue: '',
+        isNumeric: true
+    }
+}
+
 const plugin: SortingUnitMetricPlugin = {
     name: 'UnitSnrs',
     label: 'SNR',
@@ -19,7 +27,8 @@ const plugin: SortingUnitMetricPlugin = {
         newHitherJobMethod: true,
         useClientCache: true
     },
-    component: UnitSnrs
+    component: UnitSnrs,
+    getRecordValue: getRecordValue
 }
 
 export default plugin

--- a/src/extensions/unitstable/Units/metricPlugins/common.ts
+++ b/src/extensions/unitstable/Units/metricPlugins/common.ts
@@ -21,7 +21,6 @@ export interface MetricPlugin {
         job_handler_name?: string
     }
     component: React.ComponentType<{record: any}>
-    // comparer: (data: {[key: string]: any}) => (aval: number, bval: number, sortAscending: boolean) => number
     getRecordValue: (r: any) => MetricValue
     development?: boolean
 }
@@ -34,7 +33,7 @@ const baseNumericComparer = (a: number, b: number, sortAscending: boolean): numb
     // Don't mess with the ordering of two infinities; otherwise sort infinity as greater than finite values
     if (a === Infinity && b === Infinity) return 0
     if (a === Infinity) return sortAscending ? 1 : -1
-    if (b === Infinity) return sortAscending ? 1 : -1
+    if (b === Infinity) return sortAscending ? -1 : 1
     return sortAscending ? (a - b) : (b - a)
 }
 

--- a/src/extensions/unitstable/Units/metricPlugins/common.ts
+++ b/src/extensions/unitstable/Units/metricPlugins/common.ts
@@ -1,3 +1,8 @@
+export interface MetricValue {
+    numericValue: number,
+    stringValue: string,
+    isNumeric: boolean
+}
 export interface MetricPlugin {
     type: 'metricPlugin'
     metricName: string
@@ -16,5 +21,29 @@ export interface MetricPlugin {
         job_handler_name?: string
     }
     component: React.ComponentType<{record: any}>
+    // comparer: (data: {[key: string]: any}) => (aval: number, bval: number, sortAscending: boolean) => number
+    getRecordValue: (r: any) => MetricValue
     development?: boolean
+}
+
+const baseNumericComparer = (a: number, b: number, sortAscending: boolean): number => {
+    // if both values are NaN, mark them equal; otherwise sort NaNs after any numeric values.
+    if (isNaN(a) && isNaN(b)) return 0
+    if (isNaN(a)) return -1
+    if (isNaN(b)) return 1
+    // Don't mess with the ordering of two infinities; otherwise sort infinity as greater than finite values
+    if (a === Infinity && b === Infinity) return 0
+    if (a === Infinity) return sortAscending ? 1 : -1
+    if (b === Infinity) return sortAscending ? 1 : -1
+    return sortAscending ? (a - b) : (b - a)
+}
+
+export const sortMetricValues = (a: MetricValue, b: MetricValue, sortAscending: boolean): number => {
+    if (a.isNumeric) {
+        return baseNumericComparer(a.numericValue, b.numericValue, sortAscending)
+    } else { // it's a string
+        if (a.stringValue === b.stringValue) return 0
+        // A goes first if it's less than B and we're ascending, or it's greater than B and we're descending
+        return (a.stringValue < b.stringValue) === sortAscending ? -1 : 1
+    }
 }

--- a/src/extensions/unitstable/Units/metricPlugins/registerMetricPlugins.tsx
+++ b/src/extensions/unitstable/Units/metricPlugins/registerMetricPlugins.tsx
@@ -1,0 +1,16 @@
+import { ExtensionContext } from "../../../../extension"
+import { default as EventCountPlugin } from './EventCount'
+import { default as FiringRatePlugin } from './FiringRate'
+import { default as IsiViolationsPlugin } from './IsiViolations'
+import { default as PeakChannelsPlugin } from './PeakChannels'
+import { default as UnitSnrsPlugin } from './UnitSnrs'
+
+const registerMetricPlugins = (context: ExtensionContext) => {
+    context.registerSortingUnitMetric(EventCountPlugin)
+    context.registerSortingUnitMetric(FiringRatePlugin)
+    context.registerSortingUnitMetric(IsiViolationsPlugin)
+    context.registerSortingUnitMetric(PeakChannelsPlugin)
+    context.registerSortingUnitMetric(UnitSnrsPlugin)
+}
+
+export default registerMetricPlugins

--- a/src/extensions/unitstable/unitstable.tsx
+++ b/src/extensions/unitstable/unitstable.tsx
@@ -1,9 +1,12 @@
 // LABBOX-EXTENSION: unitstable
 
 import { ExtensionContext } from "../../extension";
+import registerMetricPlugins from "./Units/metricPlugins/registerMetricPlugins";
 import Units from './Units/Units';
 
 export function activate(context: ExtensionContext) {
+    registerMetricPlugins(context)
+
     context.registerSortingView({
         name: 'Units',
         label: 'Units Table',

--- a/src/reducers/extensionContext.ts
+++ b/src/reducers/extensionContext.ts
@@ -1,15 +1,17 @@
 import { Reducer } from 'react'
-import { RecordingViewPlugin, SortingUnitViewPlugin, SortingViewPlugin } from '../extension'
+import { RecordingViewPlugin, SortingUnitMetricPlugin, SortingUnitViewPlugin, SortingViewPlugin } from '../extension'
 
 export interface State {
     sortingViews: {[key: string]: SortingViewPlugin},
     sortingUnitViews: {[key: string]: SortingUnitViewPlugin},
-    recordingViews: {[key: string]: RecordingViewPlugin}
+    recordingViews: {[key: string]: RecordingViewPlugin},
+    sortingUnitMetrics: {[key: string]: SortingUnitMetricPlugin}
 }
 const initialState: State = {
     sortingViews: {},
     sortingUnitViews: {},
-    recordingViews: {}
+    recordingViews: {},
+    sortingUnitMetrics: {}
 }
 
 export interface RegisterSortingViewAction {
@@ -36,7 +38,15 @@ const isRegisterRecordingViewAction = (x: any): x is RegisterRecordingViewAction
     x.type === 'REGISTER_RECORDING_VIEW'
 )
 
-export type Action = RegisterSortingViewAction | RegisterSortingUnitViewAction | RegisterRecordingViewAction
+export interface RegisterSortingUnitMetricAction {
+    type: 'REGISTER_SORTING_UNIT_METRIC'
+    sortingUnitMetric: SortingUnitMetricPlugin
+}
+const isRegisterSortingUnitMetricAction = (x: any): x is RegisterSortingUnitMetricAction => (
+    x.type === 'REGISTER_SORTING_UNIT_METRIC'
+)
+
+export type Action = RegisterSortingViewAction | RegisterSortingUnitViewAction | RegisterRecordingViewAction | RegisterSortingUnitMetricAction
 
 const isArray = <T>(x: any): x is T[] => {
     return (Array.isArray(x))
@@ -77,6 +87,15 @@ const extensionContext: Reducer<State, Action> = (state: State = initialState, a
             recordingViews: {
                 ...state.recordingViews,
                 [action.recordingView.name]: action.recordingView
+            }
+        }
+    }
+    else if (isRegisterSortingUnitMetricAction(action)) {
+        return {
+            ...state,
+            sortingUnitMetrics: {
+                ...state.sortingUnitMetrics,
+                [action.sortingUnitMetric.name]: action.sortingUnitMetric
             }
         }
     }

--- a/src/reducers/sortings.ts
+++ b/src/reducers/sortings.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'react'
-import { ADD_SORTING, ADD_UNIT_LABEL, DELETE_ALL_SORTINGS_FOR_RECORDINGS, DELETE_SORTINGS, REMOVE_UNIT_LABEL, SET_SORTING_INFO } from '../actions'
+import { ADD_SORTING, ADD_UNIT_LABEL, DELETE_ALL_SORTINGS_FOR_RECORDINGS, DELETE_SORTINGS, REMOVE_UNIT_LABEL, SET_EXTERNAL_SORTING_UNIT_METRICS, SET_SORTING_INFO } from '../actions'
 
 export interface SortingInfo {
     unit_ids: number[]
@@ -7,15 +7,22 @@ export interface SortingInfo {
 
 type Label = string
 
+export type ExternalSortingUnitMetric = {name: string, label: string, tooltip?: string, data: {[key: string]: number}}
+
 export interface Sorting {
     sortingId: string
     sortingLabel: string
     sortingPath: string
     sortingObject: any
-    sortingInfo: SortingInfo
     recordingId: string
-    unitCuration: {[key: string]: {labels: Label[]}}
-    unitMetrics: {[key: string]: {[key: string]: number}}
+    recordingPath: string
+    recordingObject: any
+    externalUnitMetricsUri?: string
+
+    // the following are not imported
+    sortingInfo?: SortingInfo
+    externalUnitMetrics?: ExternalSortingUnitMetric[]
+    unitCuration?: {[key: string]: {labels: Label[]}}
 }
 
 export interface AddSortingAction {
@@ -51,6 +58,15 @@ const isSetSortingInfoAction = (x: any): x is SetSortingInfoAction => (
     x.type === SET_SORTING_INFO
 )
 
+export interface SetExternalSortingUnitMetricsAction {
+    type: 'SET_EXTERNAL_SORTING_UNIT_METRICS'
+    sortingId: string
+    externalUnitMetrics: ExternalSortingUnitMetric[]
+}
+const isSetExternalSortingUnitMetricsAction = (x: any): x is SetExternalSortingUnitMetricsAction => (
+    x.type === SET_EXTERNAL_SORTING_UNIT_METRICS
+)
+
 export interface AddUnitLabelAction {
     type: 'ADD_UNIT_LABEL'
     sortingId: string
@@ -72,7 +88,7 @@ const isRemoveUnitLabelAction = (x: any): x is RemoveUnitLabelAction => (
 )
 
 export type State = Sorting[]
-export type Action = AddSortingAction | DeleteSortingsAction | DeleteAllSortingsForRecordingsAction | SetSortingInfoAction | AddUnitLabelAction | RemoveUnitLabelAction
+export type Action = AddSortingAction | DeleteSortingsAction | DeleteAllSortingsForRecordingsAction | SetSortingInfoAction | AddUnitLabelAction | RemoveUnitLabelAction | SetExternalSortingUnitMetricsAction
 const initialState: State = []
 
 // the reducer
@@ -111,6 +127,16 @@ const sortings: Reducer<State, Action> = (state: State = initialState, action: A
                 {
                     ...s,
                     unitCuration: unitCurationReducer(s.unitCuration, action)
+                }
+            ): s
+        ))
+    }
+    else if (isSetExternalSortingUnitMetricsAction(action)) {
+        return state.map(s => (
+            s.sortingId === action.sortingId ? (
+                {
+                    ...s,
+                    externalUnitMetrics: action.externalUnitMetrics
                 }
             ): s
         ))

--- a/src/reducers/sortings.ts
+++ b/src/reducers/sortings.ts
@@ -19,7 +19,6 @@ export interface Sorting {
     recordingObject: any
     externalUnitMetricsUri?: string
 
-    // the following are not imported
     sortingInfo?: SortingInfo
     externalUnitMetrics?: ExternalSortingUnitMetric[]
     unitCuration?: {[key: string]: {labels: Label[]}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,7 +1870,7 @@
     "@types/react" "*"
     "@types/react-router" "*"
 
-"@types/react-router@*":
+"@types/react-router@*", "@types/react-router@^5.1.8":
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.8.tgz#4614e5ba7559657438e17766bb95ef6ed6acc3fa"
   integrity sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==


### PR DESCRIPTION
Supporting external sorting unit metrics. Can be tested using this example:

https://gist.github.com/magland/e01d114cd8e54029dfc7402cf50ce0cf

It works like this.
```
# Create a test sorting unit metric
    test_metric = dict(
        name='test_metric',
        label='Test',
        tooltip='Timepoint of first firing event',
        data=dict(zip([str(uid) for uid in unit_ids], [sorting.get_unit_spike_train(unit_id=uid)[0] for uid in unit_ids]))
    )
    external_unit_metrics = [test_metric]
```

Then include externalUnitMetricsUri in the imported sorting object:

```
    le_sortings.append(dict(
        sortingId='loren_example1:mountainsort4',
        sortingLabel='loren_example1:mountainsort4',
        sortingPath=kp.store_object(sorting.object(), basename='loren_example-mountainsort4.json'),
        sortingObject=sorting.object(),
        recordingId='loren_example1',
        recordingPath=kp.store_object(recording.object(), basename='loren_example1.json'),
        recordingObject=recording.object(),
        externalUnitMetricsUri=kp.store_object(external_unit_metrics, basename='unit_metrics.json'),
        description='''
        Example from Loren Frank (MountainSort4)
        '''.strip()
    ))
```

When labbox sees that field in the imported Sorting, it will retrieve the data and fill in the externalUnitMetrics.

That will then be displayed on the Units table.

These metrics are handled differently from the labbox-computed metrics (via the metrics plugins). But we'll need to figure out how to organize them under the same common interface so that functionality does not need to be duplicated throughout. @jsoules 