### PR TITLE
Implement auto-rotation of electrode map for better fit.

### DIFF
--- a/python/labbox_ephys/extractors/labboxephysrecordingextractor.py
+++ b/python/labbox_ephys/extractors/labboxephysrecordingextractor.py
@@ -41,7 +41,6 @@ def _listify_ndarray(x: np.ndarray) -> list:
         raise Exception('Cannot listify ndarray with {} dims.'.format(x.ndim))
 
 def _try_mda_create_object(arg: Union[str, dict]) -> Union[None, dict]:
-    print(f'Entered _try_mda_create_object() with arg {arg}')
     if isinstance(arg, str):
         path = arg
         if path.startswith('sha1dir') or path.startswith('/'):
@@ -54,9 +53,7 @@ def _try_mda_create_object(arg: Union[str, dict]) -> Union[None, dict]:
                     geom_path_resolved = kp.load_file(geom_path)
                     assert geom_path_resolved is not None, f'Unable to load geom.csv from: {geom_path}'
                     params = kp.load_object(params_path)
-                    print('A')
                     assert params is not None, f'Unable to load params.json from: {params_path}'
-                    print('B')
                     geom = _load_geom_from_csv(geom_path_resolved)
                     return dict(
                         recording_format='mda',

--- a/python/labbox_ephys/extractors/labboxephysrecordingextractor.py
+++ b/python/labbox_ephys/extractors/labboxephysrecordingextractor.py
@@ -41,6 +41,7 @@ def _listify_ndarray(x: np.ndarray) -> list:
         raise Exception('Cannot listify ndarray with {} dims.'.format(x.ndim))
 
 def _try_mda_create_object(arg: Union[str, dict]) -> Union[None, dict]:
+    print(f'Entered _try_mda_create_object() with arg {arg}')
     if isinstance(arg, str):
         path = arg
         if path.startswith('sha1dir') or path.startswith('/'):
@@ -53,7 +54,9 @@ def _try_mda_create_object(arg: Union[str, dict]) -> Union[None, dict]:
                     geom_path_resolved = kp.load_file(geom_path)
                     assert geom_path_resolved is not None, f'Unable to load geom.csv from: {geom_path}'
                     params = kp.load_object(params_path)
+                    print('A')
                     assert params is not None, f'Unable to load params.json from: {params_path}'
+                    print('B')
                     geom = _load_geom_from_csv(geom_path_resolved)
                     return dict(
                         recording_format='mda',

--- a/src/containers/RecordingView.js
+++ b/src/containers/RecordingView.js
@@ -53,8 +53,9 @@ const RecordingView = ({ recordingId, recording, sortings, history, documentInfo
       </Grid>
       {
           sortByPriority(recordingViews).filter(rv => (!rv.disabled)).map(rv => (
-            <Expandable label={rv.label} defaultExpanded={rv.defaultExpanded ? true : false}>
+            <Expandable label={rv.label} defaultExpanded={rv.defaultExpanded ? true : false} key={'rv-' + rv.name}>
               <rv.component
+                key={'rvc-' + rv.name}
                 recording={recording}
               />
             </Expandable>


### PR DESCRIPTION
Fixes issue #128.

Note, solution depends on `ElectrodeGeometryWidget.tsx` not interacting with the props electrode list directly, but instead interacting with the updated state variable (electrodes that have been through preprocessing to generate bounding boxes). Limiting direct interaction with props in favor of values that have been preprocessed in the state change hook is probably a best practice, but we'll need to stick to that as a pattern.