### PR TITLE
Fix 147: Add unison, unison-fsmonitor to devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,6 +100,10 @@ RUN pip install matplotlib mpld3
 # nano
 RUN apt-get install -y nano
 
+# unison and unison-fsmonitor
+RUN apt-get install unison
+RUN curl -Lo /usr/local/bin/unison-fsmonitor https://github.com/TentativeConvert/Syndicator/raw/master/unison-binaries/unison-fsmonitor && chmod a+x /usr/local/bin/unison-fsmonitor
+
 # # See: https://blog.miguelgrinberg.com/post/how-to-deploy-a-react--flask-project
 # ##### nginx, etc
 # RUN apt-get update && apt-get install -y nginx

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,5 @@
     "cSpell.enableFiletypes": [
         "!javascript",
         "!python"
-    ],
-    "python.pythonPath": "/home/magland/miniconda3/envs/dev/bin/python"
+    ]
 }


### PR DESCRIPTION
Real easy small change.

Also removed `pythonpath` variable from `settings.json`, as vscode's plugins say it is now outdated and not used.