### PR TITLE
canvaswidget layers get their own props

### DIFF
--- a/jupyterlab/labbox_ephys_widgets_jp/src/raindrop.tsx
+++ b/jupyterlab/labbox_ephys_widgets_jp/src/raindrop.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CanvasWidget from './extensions/CanvasWidget';
 import { CanvasPainter } from './extensions/CanvasWidget/CanvasPainter';
-import { CanvasWidgetLayer, ClickEvent, ClickEventType, useCanvasWidgetLayer, useCanvasWidgetLayers } from './extensions/CanvasWidget/CanvasWidgetLayer';
+import { CanvasWidgetLayer, ClickEvent, ClickEventType } from './extensions/CanvasWidget/CanvasWidgetLayer';
 import { TransformationMatrix, Vec2 } from './extensions/CanvasWidget/Geometry';
 
 interface Raindrop {
@@ -82,8 +82,8 @@ interface Props {
 }
 
 const RaindropWidget: React.FunctionComponent<Props> = () => {
-  const layer = useCanvasWidgetLayer(createLayer)
-  const layers = useCanvasWidgetLayers([layer])
+  const layer = useLayer(createLayer)
+  const layers = useLayers([layer])
   return (
     <CanvasWidget
       layers={layers}

--- a/src/extensions/averagewaveforms/AverageWaveformPlotNew.tsx
+++ b/src/extensions/averagewaveforms/AverageWaveformPlotNew.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CanvasWidget, { funcToTransform } from '../CanvasWidget';
 import { CanvasPainter, PainterPath } from '../CanvasWidget/CanvasPainter';
-import { CanvasWidgetLayer, useCanvasWidgetLayer, useCanvasWidgetLayers } from '../CanvasWidget/CanvasWidgetLayer';
+import { CanvasWidgetLayer, useLayer } from '../CanvasWidget/CanvasWidgetLayer';
 import { Vec2 } from '../CanvasWidget/Geometry';
 
 interface PlotData {
@@ -122,13 +122,13 @@ const createPlotWaveformLayer = () => {
 }
 
 const HelperPlot = (props: HelperPlotProps) => {
-    const plotWaveformLayer = useCanvasWidgetLayer(createPlotWaveformLayer)
-    const layers = useCanvasWidgetLayers([plotWaveformLayer])
+    const plotWaveformLayer = useLayer(createPlotWaveformLayer, props)
     return (
         <div style={{gridArea: "2 / 1 / 7 / 2"}}>
-            <CanvasWidget<HelperPlotProps>
-                layers={layers || []}
-                layerProps={props}
+            <CanvasWidget
+                layers={[plotWaveformLayer]}
+                width={props.width}
+                height={props.height}
             />
         </div>
     )

--- a/src/extensions/averagewaveforms2/AverageWaveformsView/AverageWaveformWidget.tsx
+++ b/src/extensions/averagewaveforms2/AverageWaveformsView/AverageWaveformWidget.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import CanvasWidget from '../../CanvasWidget';
-import { useCanvasWidgetLayer, useCanvasWidgetLayers } from "../../CanvasWidget/CanvasWidgetLayer";
+import { useLayer } from '../../CanvasWidget/CanvasWidgetLayer';
 import { createElectrodesLayer, ElectrodeColors } from './electrodesLayer';
 import { createWaveformLayer, WaveformColors } from './waveformLayer';
 
@@ -42,23 +42,23 @@ const AverageWaveformWidget: FunctionComponent<Props> = (props) => {
     const waveformColors: WaveformColors = {
         base: 'black'
     }
-    const electrodesLayer = useCanvasWidgetLayer(createElectrodesLayer)
-    const waveformLayer = useCanvasWidgetLayer(createWaveformLayer)
-    const layers = useCanvasWidgetLayers([electrodesLayer, waveformLayer])
+    const layerProps = {
+        ...props,
+        electrodeOpts: {
+            colors: electrodeColors,
+            showLabels: false
+        },
+        waveformOpts: {
+            colors: waveformColors,
+            waveformWidth: 2
+        }
+    }
+    const electrodesLayer = useLayer(createElectrodesLayer, layerProps)
+    const waveformLayer = useLayer(createWaveformLayer, layerProps)
     return (
         <CanvasWidget
-            layers={layers}
-            layerProps={{
-                ...props,
-                electrodeOpts: {
-                    colors: electrodeColors,
-                    showLabels: false
-                },
-                waveformOpts: {
-                    colors: waveformColors,
-                    waveformWidth: 2
-                }
-            }}
+            layers={[electrodesLayer, waveformLayer]}
+            {...{width: props.width, height: props.height}}
         />
     )
 }

--- a/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometry.tsx
+++ b/src/extensions/devel/ElectrodeGeometryTest/ElectrodeGeometry.tsx
@@ -1,7 +1,7 @@
 import { norm } from 'mathjs'
 import React from 'react'
 import CanvasWidget from '../../CanvasWidget/CanvasWidget'
-import { CanvasWidgetLayer, useCanvasWidgetLayer, useCanvasWidgetLayers } from '../../CanvasWidget/CanvasWidgetLayer'
+import { CanvasWidgetLayer, useLayer } from '../../CanvasWidget/CanvasWidgetLayer'
 import { getHeight, getWidth, RectangularRegion } from '../../CanvasWidget/Geometry'
 import { AnimatedLayerState, handleAnimatedClick, paintAnimationLayer } from './AnimatedLayer'
 import { ClickHistoryState, handleClickTrail, paintClickLayer } from './ClickHistoryLayer'
@@ -152,17 +152,16 @@ const ElectrodeGeometry = (props: ElectrodeGeometryProps) => {
         electrodeRadius: radius,
     }
 
-    const testLayer = useCanvasWidgetLayer(createTestLayer)
-    const dragLayer = useCanvasWidgetLayer(createDragLayer)
-    const clickLayer = useCanvasWidgetLayer(createClickLayer)
-    const animatedLayer = useCanvasWidgetLayer(createAnimatedLayer)
-    const layers = useCanvasWidgetLayers([testLayer, dragLayer, clickLayer, animatedLayer])
+    const testLayer = useLayer(createTestLayer, layerProps)
+    const dragLayer = useLayer(createDragLayer, layerProps)
+    const clickLayer = useLayer(createClickLayer, layerProps)
+    const animatedLayer = useLayer(createAnimatedLayer, layerProps)
 
     return (
-        <CanvasWidget<ElectrodeLayerProps>
+        <CanvasWidget
             key='canvas'
-            layers={layers || []}
-            layerProps={layerProps}
+            layers={[testLayer, dragLayer, clickLayer, animatedLayer]}
+            {...{width, height}}
         />
     )
 }

--- a/src/extensions/electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget.tsx
+++ b/src/extensions/electrodegeometry/ElectrodeGeometryWidget/ElectrodeGeometryWidget.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { funcToTransform } from '../../CanvasWidget'
 import { CanvasPainter } from '../../CanvasWidget/CanvasPainter'
 import CanvasWidget from '../../CanvasWidget/CanvasWidget'
-import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, DiscreteMouseEventHandler, DragHandler, useCanvasWidgetLayer, useCanvasWidgetLayers } from "../../CanvasWidget/CanvasWidgetLayer"
+import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, DiscreteMouseEventHandler, DragHandler, useLayer } from "../../CanvasWidget/CanvasWidgetLayer"
 import { getBoundingBoxForEllipse, getHeight, getWidth, pointIsInEllipse, RectangularRegion, rectangularRegionsIntersect, transformDistance, Vec2 } from '../../CanvasWidget/Geometry'
 
 
@@ -270,14 +270,13 @@ const createLayer = () => {
 
 type LayerArray = Array<CanvasWidgetLayer<ElectrodeLayerProps, ElectrodeLayerState>> 
 const ElectrodeGeometryCanvas = (props: ElectrodeLayerProps) => {
-    const layer = useCanvasWidgetLayer(createLayer)
-    const layers = useCanvasWidgetLayers([layer])
+    const layer = useLayer(createLayer, props)
 
     return (
-        <CanvasWidget<ElectrodeLayerProps>
+        <CanvasWidget
             key='electrodeGeometryCanvas'
-            layers={layers || []}
-            layerProps={props}
+            layers={[layer]}
+            {...{width: props.width, height: props.height}}
         />
     )
 }

--- a/src/extensions/timeseries/TimeWidgetNew/TimeSpanWidget.tsx
+++ b/src/extensions/timeseries/TimeWidgetNew/TimeSpanWidget.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { funcToTransform } from '../../CanvasWidget';
 import { CanvasPainter } from '../../CanvasWidget/CanvasPainter';
 import CanvasWidget from '../../CanvasWidget/CanvasWidget';
-import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, useCanvasWidgetLayer, useCanvasWidgetLayers } from '../../CanvasWidget/CanvasWidgetLayer';
+import { CanvasDragEvent, CanvasWidgetLayer, ClickEvent, ClickEventType, useLayer } from '../../CanvasWidget/CanvasWidgetLayer';
 import { Vec2 } from '../../CanvasWidget/Geometry';
 
 
@@ -126,19 +126,19 @@ const createTimeSpanLayer = () => {
 
 const TimeSpanWidget: FunctionComponent<Props> = (props) => {
 
-    const timeSpanLayer = useCanvasWidgetLayer(createTimeSpanLayer)
-    const layers = useCanvasWidgetLayers([timeSpanLayer])
+    const layerProps = {
+        width: props.width,
+        height: props.height,
+        info: props.info,
+        onCurrentTimeChanged: props.onCurrentTimeChanged,
+        onTimeRangeChanged: props.onTimeRangeChanged
+    }
+    const timeSpanLayer = useLayer(createTimeSpanLayer, layerProps)
 
     return (
         <CanvasWidget
-            layers={layers || []}
-            layerProps={{
-                width: props.width,
-                height: props.height,
-                info: props.info,
-                onCurrentTimeChanged: props.onCurrentTimeChanged,
-                onTimeRangeChanged: props.onTimeRangeChanged
-            }}
+            layers={[timeSpanLayer]}
+            {...{width: props.width, height: props.height}}
         />
     )
 }


### PR DESCRIPTION
In order to make layers that are shareable between multiple components (for example elec geom layer being behind multiple views), it is important that the prop types for layers are allowed to be different for different layers within the same canvas widget.