### PR TITLE
Prevent scroll wheel from scrolling time series widget without focus

### DIFF
--- a/src/extensions/CanvasWidget/CanvasWidget.tsx
+++ b/src/extensions/CanvasWidget/CanvasWidget.tsx
@@ -98,13 +98,21 @@ const CanvasWidget = (props: Props) => {
     }, [])
 
     useEffect(() => {
+        if (divElement) {
+            (divElement as any)['_hasFocus'] = hasFocus
+        }
+    }, [hasFocus, divElement])
+
+    useEffect(() => {
         // this should be called only when the divElement has been first set (above)
         // or when the layers (prop) has changed (or if preventDefaultWheel has changed)
         // we set the canvas elements on the layers and schedule repaints
         if (!divElement) return
         if (!layers) return
         const stopScrollEvent = (e: Event) => {
-            e.preventDefault()
+            if ((divElement as any)['_hasFocus']) {
+                e.preventDefault()
+            }
         }
         layers.forEach((L, i) => {
             const canvasElement = divElement.children[i]

--- a/src/extensions/CanvasWidget/CanvasWidget.tsx
+++ b/src/extensions/CanvasWidget/CanvasWidget.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useReducer, useState } from 'react'
-import { CanvasWidgetLayer, ClickEventType, formClickEventFromMouseEvent, KeyEventType } from './CanvasWidgetLayer'
+import { CanvasWidgetLayer, ClickEventType, formClickEventFromMouseEvent, KeyEventType, MousePresenceEventType } from './CanvasWidgetLayer'
 import { Vec2, Vec4 } from './Geometry'
 
 // This class serves three purposes:
@@ -174,6 +174,13 @@ const CanvasWidget = (props: Props) => {
         }
     }, [layers, dragState])
 
+    const _handleMousePresenceEvents = useCallback((e: React.MouseEvent<HTMLCanvasElement, MouseEvent>, type: MousePresenceEventType) => {
+        if (!layers) return
+        for (const l of layers) {
+            l && l.handleMousePresenceEvent(e, type)
+        }
+    }, [layers])
+
     const _handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
         const { point, mouseButton, modifiers } = formClickEventFromMouseEvent(e, ClickEventType.Move)
         dispatchDrag({type: COMPUTE_DRAG, mouseButton: mouseButton === 1, point: point, shift: modifiers.shift || false})
@@ -194,12 +201,12 @@ const CanvasWidget = (props: Props) => {
     }, [_handleDiscreteMouseEvents, dispatchDrag])
 
     const _handleMouseEnter = useCallback((e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
-        // todo
-    }, [])
+        _handleMousePresenceEvents(e, MousePresenceEventType.Enter)
+    }, [_handleMousePresenceEvents])
 
     const _handleMouseLeave = useCallback((e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) => {
-        // todo
-    }, [])
+        _handleMousePresenceEvents(e, MousePresenceEventType.Leave)
+    }, [_handleMousePresenceEvents])
 
     const _handleWheel = useCallback((e: React.WheelEvent<HTMLCanvasElement>) => {
         for (let l of layers) {

--- a/src/extensions/CanvasWidget/CanvasWidgetLayer.ts
+++ b/src/extensions/CanvasWidget/CanvasWidgetLayer.ts
@@ -283,6 +283,7 @@ export class CanvasWidgetLayer<LayerProps extends BaseLayerProps, State extends 
 
     handleWheelEvent(e: React.WheelEvent<HTMLCanvasElement>) {
         if (this._wheelEventHandlers.length === 0) return
+        
         const wheelEvent = formWheelEvent(e)
         for (let fn of this._wheelEventHandlers) {
             fn(wheelEvent, this)

--- a/src/extensions/CanvasWidget/CanvasWidgetLayer.ts
+++ b/src/extensions/CanvasWidget/CanvasWidgetLayer.ts
@@ -18,8 +18,25 @@ export interface ClickEvent {
     type: ClickEventType
 }
 
-export interface WheelEvent {
-    deltaY: number
+export interface ClickEventModifiers {
+    alt?: boolean,
+    ctrl?: boolean,
+    shift?: boolean
+}
+
+export enum ClickEventType {
+    Move = 'MOVE',
+    Press = 'PRESS',
+    Release = 'RELEASE'
+}
+export type ClickEventTypeStrings = keyof typeof ClickEventType
+
+export interface CanvasDragEvent {
+    dragRect: RectangularRegion,
+    released: boolean,
+    shift: boolean, // might extend this to the full modifier set later
+    anchor?: Vec2,
+    position?: Vec2
 }
 
 export interface KeyboardEvent {
@@ -32,27 +49,20 @@ export enum KeyEventType {
     Release = 'RELEASE'
 }
 
-export interface ClickEventModifiers {
-    alt?: boolean,
-    ctrl?: boolean,
-    shift?: boolean
+export interface MousePresenceEvent {
+    type: MousePresenceEventType
 }
 
-export enum ClickEventType {
-    Move = 'MOVE',
-    Press = 'PRESS',
-    Release = 'RELEASE'
-    // TODO: Wheel, etc?
+export enum MousePresenceEventType {
+    Enter = 'ENTER',
+    Leave = 'LEAVE',
+    Out = 'OUT'
 }
-export type ClickEventTypeStrings = keyof typeof ClickEventType
 
-export interface CanvasDragEvent {
-    dragRect: RectangularRegion,
-    released: boolean,
-    shift: boolean, // might extend this to the full modifier set later
-    anchor?: Vec2,
-    position?: Vec2
+export interface WheelEvent {
+    deltaY: number
 }
+
 
 // These two handlers, and the EventHandlerSet, could all instead have parameterized types.
 // But I couldn't figure out how to make the inheritance work right, so I bagged it.
@@ -61,14 +71,16 @@ export interface CanvasDragEvent {
 // to values outside their own scope.
 export type DiscreteMouseEventHandler = (event: ClickEvent, layer: CanvasWidgetLayer<any, any>) => void
 export type DragHandler = (layer: CanvasWidgetLayer<any, any>,  dragEvent: CanvasDragEvent) => void
-export type WheelEventHandler = (event: WheelEvent, layer: CanvasWidgetLayer<any, any>) => void
 export type KeyboardEventHandler = (event: KeyboardEvent, layer: CanvasWidgetLayer<any, any>) => boolean // return false to prevent default
+export type MousePresenceEventHandler = (event: MousePresenceEvent, layer: CanvasWidgetLayer<any, any>) => void
+export type WheelEventHandler = (event: WheelEvent, layer: CanvasWidgetLayer<any, any>) => void
 
 export interface EventHandlerSet {
     discreteMouseEventHandlers?: DiscreteMouseEventHandler[],
     dragHandlers?:   DragHandler[],
+    keyboardEventHandlers?: KeyboardEventHandler[],
+    mousePresenceEventHandlers?: MousePresenceEventHandler[],
     wheelEventHandlers?: WheelEventHandler[]
-    keyboardEventHandlers?: KeyboardEventHandler[]
 }
 
 export const formClickEventFromMouseEvent = (e: React.MouseEvent<HTMLCanvasElement, MouseEvent>, t: ClickEventType, i?: TransformationMatrix): ClickEvent => {
@@ -120,8 +132,9 @@ export class CanvasWidgetLayer<LayerProps extends BaseLayerProps, State extends 
 
     _discreteMouseEventHandlers: DiscreteMouseEventHandler[] = []
     _dragHandlers: DragHandler[] = []
-    _wheelEventHandlers: WheelEventHandler[] = []
     _keyboardEventHandlers: KeyboardEventHandler[] = []
+    _mousePresenceEventHandlers: MousePresenceEventHandler[] = []
+    _wheelEventHandlers: WheelEventHandler[] = []
 
     _refreshRate = 120 // Hz
 
@@ -131,8 +144,9 @@ export class CanvasWidgetLayer<LayerProps extends BaseLayerProps, State extends 
         this._onPropsChange = onPropsChange
         this._discreteMouseEventHandlers = handlers?.discreteMouseEventHandlers || []
         this._dragHandlers = handlers?.dragHandlers || []
-        this._wheelEventHandlers = handlers?.wheelEventHandlers || []
         this._keyboardEventHandlers = handlers?.keyboardEventHandlers || []
+        this._mousePresenceEventHandlers = handlers?.mousePresenceEventHandlers || []
+        this._wheelEventHandlers = handlers?.wheelEventHandlers || []
         this._transformMatrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]] as any as TransformationMatrix
         this._inverseMatrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]] as any as TransformationMatrix
     }
@@ -248,14 +262,6 @@ export class CanvasWidgetLayer<LayerProps extends BaseLayerProps, State extends 
         }
     }
 
-    handleWheelEvent(e: React.WheelEvent<HTMLCanvasElement>) {
-        if (this._wheelEventHandlers.length === 0) return
-        const wheelEvent = formWheelEvent(e)
-        for (let fn of this._wheelEventHandlers) {
-            fn(wheelEvent, this)
-        }
-    }
-
     handleKeyboardEvent(type: KeyEventType, e: React.KeyboardEvent<HTMLDivElement>): boolean {
         if (this._keyboardEventHandlers.length === 0) return true
         const keyboardEvent = formKeyboardEvent(type, e)
@@ -265,6 +271,22 @@ export class CanvasWidgetLayer<LayerProps extends BaseLayerProps, State extends 
                 passEventBackToUi = false
         }
         return passEventBackToUi
+    }
+
+    handleMousePresenceEvent(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>, type: MousePresenceEventType) {
+        if (this._mousePresenceEventHandlers.length === 0) return
+        const presenceEvent = { type: type }
+        for (let fn of this._mousePresenceEventHandlers) {
+            fn(presenceEvent, this)
+        }
+    }
+
+    handleWheelEvent(e: React.WheelEvent<HTMLCanvasElement>) {
+        if (this._wheelEventHandlers.length === 0) return
+        const wheelEvent = formWheelEvent(e)
+        for (let fn of this._wheelEventHandlers) {
+            fn(wheelEvent, this)
+        }
     }
 }
 

--- a/src/extensions/timeseries/TimeWidgetNew/mainLayer.ts
+++ b/src/extensions/timeseries/TimeWidgetNew/mainLayer.ts
@@ -13,7 +13,7 @@ interface LayerState {
     inverseTransformations: TransformationMatrix[]
     anchorTimepoint: number | null
     dragging: boolean
-    listeningToWheel: boolean
+    captureWheel: boolean
     paintStatus: {
         paintCode: number,
         completenessFactor: number
@@ -26,7 +26,7 @@ const initialLayerState = {
     inverseTransformations: [],
     anchorTimepoint: null,
     dragging: false,
-    listeningToWheel: false,
+    captureWheel: false,
     paintStatus: {
         paintCode: 0,
         completenessFactor: 0.2
@@ -111,7 +111,7 @@ export const handleClick: DiscreteMouseEventHandler = (e: ClickEvent, layer: Can
         const p = transformPoint(inverseTransformations[i], e.point)
         if ((0 <= p[1]) && (p[1] <= 1)) {
             if (e.type === ClickEventType.Press) {
-                layer.setState({...state, listeningToWheel: true, anchorTimepoint: p[0], dragging: false})
+                layer.setState({...state, captureWheel: true, anchorTimepoint: p[0], dragging: false})
             }
             else if (e.type === ClickEventType.Release) {
                 if (!dragging) {
@@ -125,7 +125,7 @@ export const handleClick: DiscreteMouseEventHandler = (e: ClickEvent, layer: Can
 
 export const handleMouseOut: MousePresenceEventHandler = (e: MousePresenceEvent, layer: CanvasWidgetLayer<TimeWidgetLayerProps, LayerState>) => {
     if (e.type !== MousePresenceEventType.Leave) return
-    layer.setState({...layer.getState(), listeningToWheel: false})
+    layer.setState({...layer.getState(), captureWheel: false})
 }
 
 const shiftTimeRange = (timeRange: {min: number, max: number}, shift: number): {min: number, max: number} => {
@@ -159,7 +159,7 @@ export const handleDrag: DragHandler = (layer: CanvasWidgetLayer<TimeWidgetLayer
 export const handleWheel: WheelEventHandler = (e: WheelEvent, layer: CanvasWidgetLayer<TimeWidgetLayerProps, LayerState>) => {
     const props = layer.getProps()
     if (!props) return
-    const listening = layer.getState().listeningToWheel
+    const listening = layer.getState().captureWheel
     if (!listening) return
     if (e.deltaY > 0) {
         props.onTimeZoom && props.onTimeZoom(1 / 1.15)


### PR DESCRIPTION
This PR introduces support for mouse entry and exit events in the CanvasWidget framework. It also makes the `mainLayer` of the `TimeSeries` widget series track whether it has focus (defined as having received a click since the last time the mouse left the window); if it loses focus, then it will no longer respond to mouse events.

Unfortunately, the TimeSeriesWidget series still captures mouse wheel events regardless of whether the layer has focus--this results in the window not scrolling on mouse events when the mouse is over the widget, even though the widget is blurred and we would like the window to scroll. Probably the easiest solution to this would be to allow the `CanvasWidget` object, rather than the individual layers, to track its focus status and `preventDefault` on mouse wheel events if the widget is focused. Unfortunately, React seems to be attaching such events in a way that Chrome and Firefox think they should be passive elements, which means they are not eligible to execute a `preventDefault`. This is to improve wheel and touch scrolling performance in certain circumstances; however, it's inconvenient for us. It probably also indicates that the event listener is being attached to the wrong element, since we don't want the whole page to ignore the event, just the `CanvasWidget`.

However, in default of seeing an actual fix for this issue in the near future, I've elected to push this code--which does contain an improvement, viz, random wheel events no longer scale the time series unintentionally--and defer the complete fix for a later date.