### PR TITLE
jupyter: import external unit metrics

### DIFF
--- a/jupyterlab/labbox_ephys_widgets_jp/labbox_ephys_widgets_jp/create_sorting_view.py
+++ b/jupyterlab/labbox_ephys_widgets_jp/labbox_ephys_widgets_jp/create_sorting_view.py
@@ -9,6 +9,7 @@ import numpy as np
 from hither.job import Job as HitherJob
 from ipywidgets import DOMWidget
 from traitlets import Dict as DictTrait
+from traitlets import List as ListTrait
 from traitlets import Unicode
 
 from ._frontend import module_name, module_version
@@ -39,6 +40,7 @@ def create_sorting_view(plugin_name: str, *, sorting: le.LabboxEphysSortingExtra
         sortingInfo = DictTrait(le.get_sorting_info(sorting_object=sorting.object(), recording_object=recording.object())).tag(sync=True)
         selection = DictTrait({}).tag(sync=True)
         curation = DictTrait({}).tag(sync=True)
+        externalUnitMetrics = ListTrait([]).tag(sync=True)
         def __init__(self) -> None:
             super().__init__()
             self._jobs_by_id: Dict[str, HitherJob] = {}

--- a/jupyterlab/labbox_ephys_widgets_jp/package.json
+++ b/jupyterlab/labbox_ephys_widgets_jp/package.json
@@ -11,6 +11,8 @@
   "files": [
     "lib/**/*.js",
     "dist/*.js",
+    "lib/**/*.css",
+    "dist/*.css",
     "css/*.css"
   ],
   "homepage": "https://github.com//labbox_ephys_widgets_jp",
@@ -31,7 +33,7 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:nbextension",
     "build:labextension": "npm run clean:labextension && mkdirp labbox_ephys_widgets_jp/labextension && cd labbox_ephys_widgets_jp/labextension && npm pack ../..",
-    "build:lib": "tsc",
+    "build:lib": "tsc && npm run copy-files",
     "build:nbextension": "webpack -p",
     "build:all": "npm run build:labextension && npm run build:nbextension",
     "clean": "npm run clean:lib && npm run clean:nbextension",
@@ -47,8 +49,9 @@
     "test:firefox": "karma start --browsers=Firefox tests/karma.conf.js",
     "test:ie": "karma start --browsers=IE tests/karma.conf.js",
     "watch": "npm-run-all -p watch:*",
-    "watch:lib": "tsc -w",
-    "watch:nbextension": "webpack --watch"
+    "watch:lib": "npm run copy-files && tsc -w",
+    "watch:nbextension": "webpack --watch",
+    "copy-files": "copyfiles -u 1 src/**/*.css lib/"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3",
@@ -83,6 +86,7 @@
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "acorn": "^7.2.0",
+    "copyfiles": "^2.4.1",
     "css-loader": "^3.2.0",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",

--- a/jupyterlab/labbox_ephys_widgets_jp/src/pluginWidgets.tsx
+++ b/jupyterlab/labbox_ephys_widgets_jp/src/pluginWidgets.tsx
@@ -9,7 +9,7 @@ import '../css/widget.css';
 import exampleSorting from './exampleSorting';
 import createCalculationPool from './extensions/common/createCalculationPool';
 import { sleepMsec } from './extensions/common/misc';
-import { CalculationPool, HitherContext, HitherJob, HitherJobOpts, Plugins, Recording, RecordingViewPlugin, Sorting, sortingCurationReducer, sortingSelectionReducer, SortingUnitMetricPlugin, SortingUnitViewPlugin, SortingViewPlugin } from './extensions/extensionInterface';
+import { CalculationPool, externalUnitMetricsReducer, HitherContext, HitherJob, HitherJobOpts, Plugins, Recording, RecordingViewPlugin, Sorting, sortingCurationReducer, sortingSelectionReducer, SortingUnitMetricPlugin, SortingUnitViewPlugin, SortingViewPlugin } from './extensions/extensionInterface';
 import registerExtensions from './registerExtensions';
 import { MODULE_NAME, MODULE_VERSION } from './version';
 
@@ -163,7 +163,8 @@ export class SortingViewModel extends DOMWidgetModel {
       sortingObject: {},
       recordingObject: {},
       curation: {},
-      selection: {}
+      selection: {},
+      externalUnitMetrics: []
     };
   }
 
@@ -236,7 +237,7 @@ const PluginComponentWrapper: FunctionComponent<PluginComponentWrapperProps> = (
   }, null)
 
   // selection
-  const [selection, selectionDispatch] = useReducer(sortingSelectionReducer, model.get('selection').selectedUnitIds ? model.get('selection') : defaultSortingSelection)
+  const [selection, selectionDispatch] = useReducer(sortingSelectionReducer, model.get('selection').selectedUnitIds ? model.get('selection') : {})
   useEffect(() => {
     if (model.get('selection') !== selection) {
       model.set('selection', selection)
@@ -249,8 +250,24 @@ const PluginComponentWrapper: FunctionComponent<PluginComponentWrapperProps> = (
       selection: model.get('selection')
     })
   }, null)
+
+  // externalUnitMetrics
+  const [externalUnitMetrics, externalUnitMetricsDispatch] = useReducer(externalUnitMetricsReducer, model.get('externalUnitMetrics') ? model.get('externalUnitMetrics') : [])
+  useEffect(() => {
+    if (model.get('externalUnitMetrics') !== externalUnitMetrics) {
+      model.set('externalUnitMetrics', externalUnitMetrics)
+      model.save_changes()
+    }
+  }, [externalUnitMetrics, model])
+  model.on('change:externalUnitMetrics', () => {
+    externalUnitMetricsDispatch({
+      type: 'SetExternalUnitMetrics',
+      externalUnitMetrics: model.get('externalUnitMetrics')
+    })
+  }, null)
   
   sorting.curation = curation
+  sorting.externalUnitMetrics = externalUnitMetrics
   return (
     <plugin.component
       sorting={sorting}

--- a/jupyterlab/labbox_ephys_widgets_jp/tsconfig.json
+++ b/jupyterlab/labbox_ephys_widgets_jp/tsconfig.json
@@ -26,5 +26,6 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.css"
   ]
 }

--- a/src/extensions/extensionInterface.ts
+++ b/src/extensions/extensionInterface.ts
@@ -172,6 +172,20 @@ export const sortingCurationReducer: Reducer<SortingCuration, SortingCurationAct
 }
 ////////////////////
 
+// This reducer is used only by the jupyter extension
+type SetExternalUnitMetricsAction = {
+    type: 'SetExternalUnitMetrics',
+    externalUnitMetrics: ExternalSortingUnitMetric[]
+}
+type ExternalUnitMetricsAction = SetExternalUnitMetricsAction
+export const externalUnitMetricsReducer: Reducer<ExternalSortingUnitMetric[], ExternalUnitMetricsAction> = (state: ExternalSortingUnitMetric[], action: ExternalUnitMetricsAction): ExternalSortingUnitMetric[] => {
+    if (action.type === 'SetExternalUnitMetrics') {
+        return action.externalUnitMetrics
+    }
+    else return state
+}
+////////////////////////////////
+
 // Sorting selection
 export type SortingSelection = {
     selectedUnitIds?: number[]


### PR DESCRIPTION
Allow importing of external unit metrics from jupyter notebook as follows:

![image](https://user-images.githubusercontent.com/3679296/102648988-77454580-4136-11eb-9179-b59ae8de5a0c.png)
