### PR TITLE
Update ci.md

### DIFF
--- a/devel/ci.md
+++ b/devel/ci.md
@@ -1,16 +1,23 @@
 # Continuous integration
 
-We use continuous integration to automatically test the typescript compilation and to automatically build new docker images and push to dockerhub.
+We use [continuous integration](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration) to automatically test the typescript compilation and to automatically build new docker images and push to dockerhub.
 
-The actions are configured in [.github/workflows](.github/workflows)
+The actions are configured in [.github/workflows](../.github/workflows)
 
 ## Installation tests
 
-See: [.github/workflows/labbox-ephys-install-tests.yml](.github/workflows/labbox-ephys-install-tests.yml)
+See: [.github/workflows/labbox-ephys-install-tests.yml](../.github/workflows/labbox-ephys-install-tests.yml)
 
-This workflow is triggered whenever a new PR is created, a PR is updated, or a new commit is pushed to the master branch. A checkmark or 'x' icon on github will indicate whether the PR passes the test. A badge on the README.md indicates whether the push to master passed the test.
+This workflow is triggered whenever a new PR (pull request) is created, a PR is updated, or a new commit is pushed to the master branch. A checkmark or 'x' icon on github will indicate whether the PR passes the test. A badge on the `README.md` indicates whether the push to master passed the test.
 
-Explain importance of using squash merge for merging PR's so that we only get one test per PR merge.
+Many PRs consist of a long chain of sequential commits, as the author refines the work. 
+But since tests are triggered with every commit merged to the main code trunk, merging such a PR as-is would
+result in the tests being run repeatedly, without providing any additional value:
+if the final state works, the test status of any intermediate
+state is immaterial. The best practice to avoid needlessly consuming
+resources and attention is to combine the commits in a feature branch into
+a single commit linking the original branch point to the final merge point. This operation is known as a
+[squash and merge](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) and should be done when merging feature branches back to master.
 
 The following part of the yml causes the test to run on the above-mentioned triggers:
 
@@ -24,7 +31,8 @@ on:
       - master
 ```
 
-It is important to run these tests using a login bash session. So we have:
+The next line [sets up the default `shell` environment used to execute all `run` steps in the job](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun). We want to use a login bash session, to ensure running of
+login-time setup from `.profile` and/or `.bashrc` (like setting up environment variables). So we have:
 
 ```yaml
 defaults:
@@ -34,7 +42,7 @@ defaults:
 
 The following code defines the actual test:
 
-```
+```yaml
 jobs:
   install_jupyterlab:
     name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -62,9 +70,14 @@ jobs:
       - run: jupyter labextension list
 ```
 
-The conda-incubator/setup-miniconda@v2 is a third party github action that gives us a conda environment for the test.
-
 The test builds and installs the jupyterlab extension.
+
+[conda-incubator/setup-miniconda@v2](https://github.com/conda-incubator/setup-miniconda) is a third party github
+action that gives us a conda environment for the test. The test constructs a matrix of
+[`operating systems` x `python versions`] and creates a test environment for each combination. It then executes
+each of the `run` commands using the default shell specified in the `defaults: run:` section (otherwise
+we'd have to call `bash` explicitly in each `run` line). If any of the `run` statements returns an error code,
+then the test is considered a failure; otherwise, it is considered to have passed.
 
 ## Build docker image on new version tag
 
@@ -72,7 +85,8 @@ The labbox-ephys-push-docker workflow lets you automatically build a new docker 
 
 To push a new release to dockerhub:
 
-* Increment the version throughout the source code. For example, to increment from 0.4.5 to 0.4.6, search/replace these strings, taking care not to increment coincidental occurrences of 0.4.5.
+* Increment the version throughout the source code. For example, to increment from 0.4.5 to 0.4.6,
+search/replace these strings, taking care not to increment coincidental occurrences of 0.4.5.
 
 * Apply a tag with the release.
 
@@ -80,7 +94,7 @@ To push a new release to dockerhub:
 git tag v0.4.6
 ```
 
-* Push and push tag
+* Push the commit with the tag:
 
 ```
 git push --tags
@@ -88,7 +102,14 @@ git push --tags
 
 See: [.github/workflows/labbox-ephys-push-docker.yml](.github/workflows/labbox-ephys-push-docker.yml)
 
-This workflow is triggered by tags that begin with the letter "v".
+This workflow is triggered by tags that begin with the letter "v":
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'
+```
 
 In order to push to Dockerhub, a couple of secret variables are registered on github:
 


### PR DESCRIPTION
- Fix links
- Add links to outside documentation where additional background knowledge seems helpful
- Expanded a couple of points

Query: the hard-coded `tags: magland/labbox-ephys:0.4.10` in the build-and-push-image section, does this get updated too? Is the user responsible for updating it?
Query: Obviously we would like the tags of the version in the source files to match the version in the tag applied to the release, but is there any mechanism actually enforcing that these be the same?