### PR TITLE
preload step: download recording/sorting and extract snippets prior to enabling GUI

### DIFF
--- a/src/extensions/common/hither/HitherJobStatusView.tsx
+++ b/src/extensions/common/hither/HitherJobStatusView.tsx
@@ -5,20 +5,20 @@ import React, { FunctionComponent } from 'react'
 import { HitherJob } from './HitherInterface'
 
 
-const HitherJobStatusView: FunctionComponent<{job?: HitherJob, width?: number, height?: number}> = ({job, width=200, height=200}) => {
+const HitherJobStatusView: FunctionComponent<{job?: HitherJob, message?: string, width?: number, height?: number}> = ({job, message='', width=200, height=200}) => {
     if (!job) return <div>No job</div>
     return (
         <Box display="flex" width={width} height={height}>
             <Box m="auto">
                 {
                     job.status === 'running' ? (
-                        <CircularProgress />
+                        <span>[{message}] <CircularProgress /></span>
                     ): job.status === 'error' ? (
-                        <span>Error: {job.error_message}</span>
+                        <span>Error: {job.error_message} [{message}]</span>
                     ) : job.status === 'pending' ? (
-                        <FontAwesomeIcon icon={faWater} />
+                        <span>[{message}]<FontAwesomeIcon icon={faWater} /></span>
                     ) : (
-                        <span>{job.status}</span>
+                        <span>[{message}] {job.status}</span>
                     )
                 }
             </Box>

--- a/src/extensions/mountainview/MVSortingView/PreloadCheck.tsx
+++ b/src/extensions/mountainview/MVSortingView/PreloadCheck.tsx
@@ -1,0 +1,117 @@
+import { Dialog } from '@material-ui/core';
+import React, { Fragment, FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createCalculationPool, HitherContext } from '../../common/hither';
+import { Recording, Sorting } from '../../extensionInterface';
+
+interface ChildProps {
+    preloadStatus?: 'waiting' | 'running' | 'finished'
+}
+
+type Props = {
+    sorting: Sorting
+    recording: Recording
+    children: React.ReactElement<ChildProps>
+}
+
+const calculationPool = createCalculationPool({maxSimultaneous: 6})
+
+const PreloadCheck: FunctionComponent<Props> = ({ recording, sorting, children }) => {
+    const hither = useContext(HitherContext)
+    const sortingObject = sorting.sortingObject
+    const recordingObject = recording.recordingObject
+    const [error, setError] = useState<Error | null>(null)
+    const [status, setStatus] = useState<'waiting' | 'running' | 'finished'>('waiting')
+    const [message, setMessage] = useState<string>('')
+    const runningState = useRef<{sortingObject: any, recordingObject: any}>({sortingObject: sorting.sortingObject, recordingObject: recording.recordingObject})
+    const [lastLoadedData, setLastLoadedData] = useState<{recordingObject: any, sortingObject: any} | null>(null)
+
+    const matchesRunningState = useMemo(() => ((x: {recordingObject: any, sortingObject: any}) => (
+        (runningState.current.sortingObject === x.sortingObject) && (runningState.current.recordingObject === x.recordingObject)
+    )), [])
+
+    useEffect(() => {
+        if (status === 'waiting') {
+            runningState.current = {recordingObject, sortingObject}
+            setStatus('running')
+            ;(async () => {
+                try {
+                    setMessage('Checking sorting local...')
+                    const result1 = await hither.createHitherJob('preload_check_sorting_downloaded', {sorting_object: sortingObject}, {useClientCache: false, calculationPool}).wait() as {isLocal: boolean}
+                    if (!matchesRunningState({recordingObject, sortingObject})) return
+                    if (!result1.isLocal) {
+                        setMessage('Downloading sorting...')
+                        const result2 = await hither.createHitherJob('preload_download_sorting', {sorting_object: sortingObject}, {useClientCache: false, calculationPool}).wait() as {success: boolean}
+                        if (!matchesRunningState({recordingObject, sortingObject})) return
+                        if (!result2.success) {
+                            setError(new Error('Unable to download sorting.'))
+                            return
+                        }
+                    }
+
+                    setMessage('Checking recording local...')
+                    const result3 = await hither.createHitherJob('preload_check_recording_downloaded', {recording_object: recordingObject}, {useClientCache: false, calculationPool}).wait() as {isLocal: boolean}
+                    if (!matchesRunningState({recordingObject, sortingObject})) return
+                    if (!result3.isLocal) {
+                        setMessage('Downloading recording...')
+                        const result4 = await hither.createHitherJob('preload_download_recording', {recording_object: recordingObject}, {useClientCache: false, calculationPool}).wait() as {success: boolean}
+                        if (!matchesRunningState({recordingObject, sortingObject})) return
+                        if (!result4.success) {
+                            setError(new Error('Unable to download recording.'))
+                            return
+                        }
+                    }
+
+                    setMessage('Extracting snippets...')
+                    const result5 = await hither.createHitherJob('preload_extract_snippets', {recording_object: recordingObject, sorting_object: sortingObject}, {useClientCache: false, calculationPool}).wait() as string
+                    if (!matchesRunningState({recordingObject, sortingObject})) return
+                    if (!result5) {
+                        setError(new Error('Problem extracting snippets'))
+                        return
+                    }
+                    setStatus('finished')
+                    setLastLoadedData({recordingObject, sortingObject})
+                }
+                catch(err) {
+                    setError(err)
+                }
+            })()
+        }
+        else {
+            if (!matchesRunningState({recordingObject, sortingObject})) {
+                setStatus('waiting')
+            }
+        }
+    }, [sortingObject, recordingObject, status, matchesRunningState])
+
+    const child = useMemo(() => {
+        return React.cloneElement(
+            children,
+            {
+                preloadStatus: status
+            }
+        )
+    }, [children, status])
+
+    // This is important for when the bandpass filter changes so that we don't start calculating things prior to doing the preloading (e.g. snippets extraction)
+    const [lastValidChild, setLastValidChild] = useState<React.ReactElement | null>(null)
+    useEffect(() => {
+        if ((status === 'finished') && (matchesRunningState({recordingObject, sortingObject}))) setLastValidChild(child)
+    }, [child, status, recordingObject, sortingObject, matchesRunningState])
+
+    return (
+        <Fragment>
+            <Dialog
+                open={status !== 'finished'}
+            >
+                {error ? <Status message={`Error: ${error.message}`} /> : <Status message={message} />}
+            </Dialog>
+            {lastValidChild || child}
+        </Fragment>
+    )
+}
+
+const Status: FunctionComponent<{message: string}> = ({ message }) => {
+    return <div>{message}</div>
+}
+
+export default PreloadCheck

--- a/src/extensions/mountainview/MVSortingView/PreloadCheck.tsx
+++ b/src/extensions/mountainview/MVSortingView/PreloadCheck.tsx
@@ -23,7 +23,6 @@ const PreloadCheck: FunctionComponent<Props> = ({ recording, sorting, children }
     const [status, setStatus] = useState<'waiting' | 'running' | 'finished'>('waiting')
     const [message, setMessage] = useState<string>('')
     const runningState = useRef<{sortingObject: any, recordingObject: any}>({sortingObject: sorting.sortingObject, recordingObject: recording.recordingObject})
-    const [lastLoadedData, setLastLoadedData] = useState<{recordingObject: any, sortingObject: any} | null>(null)
 
     const matchesRunningState = useMemo(() => ((x: {recordingObject: any, sortingObject: any}) => (
         (runningState.current.sortingObject === x.sortingObject) && (runningState.current.recordingObject === x.recordingObject)
@@ -69,7 +68,6 @@ const PreloadCheck: FunctionComponent<Props> = ({ recording, sorting, children }
                         return
                     }
                     setStatus('finished')
-                    setLastLoadedData({recordingObject, sortingObject})
                 }
                 catch(err) {
                     setError(err)
@@ -81,7 +79,7 @@ const PreloadCheck: FunctionComponent<Props> = ({ recording, sorting, children }
                 setStatus('waiting')
             }
         }
-    }, [sortingObject, recordingObject, status, matchesRunningState])
+    }, [sortingObject, recordingObject, status, matchesRunningState, hither])
 
     const child = useMemo(() => {
         return React.cloneElement(

--- a/src/extensions/mountainview/MVSortingView/PreprocessingControl.tsx
+++ b/src/extensions/mountainview/MVSortingView/PreprocessingControl.tsx
@@ -2,11 +2,11 @@ import { MenuItem, Select } from '@material-ui/core';
 import React, { FunctionComponent, useCallback } from 'react';
 import sizeMe, { SizeMeProps } from 'react-sizeme';
 
-type PreprocessingSelection = {
+export type PreprocessingSelection = {
     filterType: 'none' | 'bandpass_filter'
 }
 
-type PreprocessingSelectionAction = {
+export type PreprocessingSelectionAction = {
     type: 'SetPreprocessingSelection',
     preprocessingSelection: PreprocessingSelection
 }

--- a/src/extensions/mountainview/mountainview.py
+++ b/src/extensions/mountainview/mountainview.py
@@ -1,7 +1,89 @@
 import labbox_ephys as le
+import hither as hi
 
 
 @le.register_sorting_view(name='MVSortingView')
 def MVSortingView(*, sorting: le.LabboxEphysSortingExtractor, recording: le.LabboxEphysRecordingExtractor):
     import labbox_ephys_widgets_jp as lew
     return lew.create_sorting_view('MVSortingView', sorting=sorting, recording=recording)
+
+###################################################################################
+# preload_check_sorting_downloaded
+@hi.function('preload_check_sorting_downloaded', '0.1.0')
+def preload_check_sorting_downloaded(labbox, sorting_object):
+    return preload_check_sorting_downloaded_2.run(sorting_object=sorting_object)
+
+@hi.function('preload_check_sorting_downloaded_2', '0.1.0')
+def preload_check_sorting_downloaded_2(sorting_object):
+    import kachery_p2p as kp
+    try:
+        kp._experimental_config(nop2p=True)
+        X = le.LabboxEphysSortingExtractor(sorting_object)
+    except:
+        return {'isLocal': False}
+    finally:
+        kp._experimental_config(nop2p=False)
+    return {'isLocal': True}
+
+###################################################################################
+# preload_download_sorting
+@hi.function('preload_download_sorting', '0.1.0')
+def preload_download_sorting(labbox, sorting_object):
+    return preload_download_sorting_2.run(sorting_object=sorting_object)
+
+@hi.function('preload_download_sorting_2', '0.1.0')
+def preload_download_sorting_2(sorting_object):
+    import kachery_p2p as kp
+    try:
+        X = le.LabboxEphysSortingExtractor(sorting_object)
+    except:
+        return {'success': False}
+    return {'success': True}
+    
+###################################################################################
+# preload_check_recording_downloaded
+@hi.function('preload_check_recording_downloaded', '0.1.0')
+def preload_check_recording_downloaded(labbox, recording_object):
+    return preload_check_recording_downloaded_2.run(recording_object=recording_object)
+
+@hi.function('preload_check_recording_downloaded_2', '0.1.0')
+def preload_check_recording_downloaded_2(recording_object):
+    import kachery_p2p as kp
+    try:
+        kp._experimental_config(nop2p=True)
+        X = le.LabboxEphysRecordingExtractor(recording_object, download=False)
+    except:
+        return {'isLocal': False}
+    finally:
+        kp._experimental_config(nop2p=False)
+    return {'isLocal': True}
+
+###################################################################################
+# preload_download_recording
+@hi.function('preload_download_recording', '0.1.0')
+def preload_download_recording(labbox, recording_object):
+    return preload_download_recording_2.run(recording_object=recording_object)
+
+@hi.function('preload_download_recording_2', '0.1.0')
+def preload_download_recording_2(recording_object):
+    import kachery_p2p as kp
+    try:
+        X = le.LabboxEphysRecordingExtractor(recording_object, download=True)
+    except:
+        return {'success': False}
+    return {'success': True}
+
+###################################################################################
+# preload_extract_snippets
+@hi.function('preload_extract_snippets', '0.1.0')
+def preload_extract_snippets(labbox, recording_object, sorting_object):
+    from labbox_ephys import prepare_snippets_h5
+    jh = labbox.get_job_handler('partition2')
+    jc = labbox.get_default_job_cache()
+    with hi.Config(
+        job_cache=jc,
+        job_handler=jh,
+        container=jh.is_remote
+    ):
+        snippets_h5 = prepare_snippets_h5.run(recording_object=recording_object, sorting_object=sorting_object, max_events_per_unit=None)
+        return snippets_h5


### PR DESCRIPTION
The downloading/extracting snippets step can be time consuming, especially for large datasets. Therefore, it is best to make sure these are loaded first prior to allowing the user to interact with the GUI. Here's a screenshot (a modal dialog says "extracting snippets"):

![image](https://user-images.githubusercontent.com/3679296/104604787-bbe7d200-564b-11eb-8317-8e1aa3dcc46d.png)
